### PR TITLE
feat(buscador): consumo del contrato v2 en el frontend (validación, perfil por composición, scopus_id)

### DIFF
--- a/src/app/search-engine/domain/services/author.service.ts
+++ b/src/app/search-engine/domain/services/author.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { map, Observable } from 'rxjs';
+import { map, Observable, shareReplay } from 'rxjs';
 import {HttpClient, HttpParams} from '@angular/common/http';
 import {
   Author,
@@ -26,6 +26,21 @@ export class AuthorService {
   rootURL: string = environment.apiCentinela;
   // dashURL: string = environment.apiDashboard;
 
+  // Slice 2 (API Composition): cache por autor del perfil compuesto. shareReplay
+  // hace que las multiples secciones (coautores, topics, anios) que consumen
+  // distintos componentes compartan UNA sola peticion a /v2/authors/{id}/profile.
+  private profileCache = new Map<string, Observable<any>>();
+
+  getAuthorProfile(id: string | number): Observable<any> {
+    const key = id.toString();
+    if (!this.profileCache.has(key)) {
+      this.profileCache.set(
+        key,
+        this.http.get<any>(`${this.rootURL}/v2/authors/${key}/profile`).pipe(shareReplay(1))
+      );
+    }
+    return this.profileCache.get(key)!;
+  }
 
   constructor(private http: HttpClient) {}
 
@@ -60,7 +75,8 @@ export class AuthorService {
   }
 
   getCoauthorsById(id: number): Observable<CoauthorInfo> {
-    return this.http.get<CoauthorInfo>(`${this.rootURL}/v1/coauthors/coauthors/${id}/coauthors_by_id/`);
+    // Slice 2: deriva de la composicion v2 en vez de llamar directo a v1.
+    return this.getAuthorProfile(id).pipe(map(p => p.coauthors as CoauthorInfo));
   }
 
   getMostRelevantAuthors(
@@ -104,20 +120,18 @@ export class AuthorService {
     return this.http.get<RandItem[]>(`${this.rootURL}random-topics`);
   }
   getTopicsById(scopus_id:number): Observable<NameValue[]> {
-    let params = new HttpParams().set('scopus_id', scopus_id.toString());
-    return this.http.get<Word[]>(`${this.rootURL}/v1/dashboard/author/get_topics/`, {params}).pipe(
-      map(response => {
-        const series: NameValue[] = response.map(t => ({
-          name: t.text.toString(),
-          value: t.size
-        }));
-        return series
-      }));
+    // Slice 2: las topics ahora vienen de la composicion v2 (misma forma {text,size}).
+    return this.getAuthorProfile(scopus_id).pipe(
+      map(p => ((p.topics || []) as Word[]).map(t => ({
+        name: t.text.toString(),
+        value: t.size
+      })))
+    );
   }
 
   getYears(scopus_id: string): Observable<AuthorYears[]> {
-    let params = new HttpParams().set('scopus_id', scopus_id.toString())
-    return this.http.get<AuthorYears[]>(`${this.rootURL}/v1/dashboard/author/get_author_years/`, {params});
+    // Slice 2: los anios ahora vienen de la composicion v2.
+    return this.getAuthorProfile(scopus_id).pipe(map(p => (p.years || []) as AuthorYears[]));
   }
 
   getLineChartInfo(scopus_id:string, name: string): Observable<LineChartInfo[]> {

--- a/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.html
+++ b/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.html
@@ -24,13 +24,13 @@
     <div class="py-3 px-4 flex md:flex-col gap-3 max-h-96 overflow-y-auto bg-white" *ngIf="affiliations && affiliations.length > 0">
       <div class="flex gap-3 items-center hover:bg-gray-50 p-1 rounded transition-colors" *ngFor="let aff of affiliations">
         <input
-          [id]="aff.scopusId"
+          [id]="aff.scopus_id"
           type="checkbox"
-          [checked]="selectedAffiliations.includes(aff.scopusId)"
+          [checked]="selectedAffiliations.includes(aff.scopus_id)"
           (change)="onClickCheckbox($any($event))"
           class="form-checkbox h-4 w-4 text-red-600 rounded border-gray-300 focus:ring-red-500 cursor-pointer"
         >
-        <label [for]="aff.scopusId" class="ml-2 text-sm text-gray-600 cursor-pointer flex-1 leading-tight">{{aff.name}}</label>
+        <label [for]="aff.scopus_id" class="ml-2 text-sm text-gray-600 cursor-pointer flex-1 leading-tight">{{aff.name}}</label>
       </div>
     </div>
   </app-filters-sidebar>

--- a/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.ts
+++ b/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.ts
@@ -28,7 +28,7 @@ export class MostRelevantAuthorsGraphComponent {
   showGraph: boolean = false
 
   authorsNumber: number = 50
-  affiliations!: { scopusId: string, name: string }[]
+  affiliations!: { scopus_id: string, name: string }[]
   selectedAffiliations: string[] = []
   noResults = false;
   isLoadingResults = false;
@@ -132,8 +132,8 @@ export class MostRelevantAuthorsGraphComponent {
   sortAffiliations() {
     if (this.affiliations) {
       this.affiliations.sort((a, b) => {
-        const aSelected = this.selectedAffiliations.includes(a.scopusId);
-        const bSelected = this.selectedAffiliations.includes(b.scopusId);
+        const aSelected = this.selectedAffiliations.includes(a.scopus_id);
+        const bSelected = this.selectedAffiliations.includes(b.scopus_id);
         if (aSelected && !bSelected) return -1;
         if (!aSelected && bSelected) return 1;
         return 0;

--- a/src/app/search-engine/presentation/home-page/pages/article-page/article-page.component.html
+++ b/src/app/search-engine/presentation/home-page/pages/article-page/article-page.component.html
@@ -23,7 +23,7 @@
             <ng-container *ngFor="let au of article?.authors">
               <span 
                 class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-50 text-red-700 cursor-pointer hover:bg-red-100 hover:shadow-sm transition-all border border-red-100" 
-                (click)="goToAuthor(au.scopusId)">
+                (click)="goToAuthor(au.scopus_id)">
                 <svg class="w-3.5 h-3.5 mr-1.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd"></path></svg>
                 {{ au.name }}
               </span>

--- a/src/app/shared/components/search-box/search-box.component.ts
+++ b/src/app/shared/components/search-box/search-box.component.ts
@@ -69,14 +69,19 @@ export class SearchBoxComponent implements OnInit{
   }
 
   triggerSearch() {
-    if (!this.inputValue || this.inputValue.trim() === '') {
+    const normalized = (this.inputValue || '').trim().replace(/\s\s+/g, ' ');
+    // Validacion espejo del agregado Consulta: mismo contrato que el 422
+    // CONTRACT_VALIDATION del microservicio v2. Requiere al menos un token
+    // alfabetico significativo (>= 2 letras); de lo contrario es semanticamente
+    // vacia. Da feedback inmediato y cierra el defecto UX-05 de Fase 1.
+    if (!normalized || !/\p{L}{2,}/u.test(normalized)) {
       this.showError = true;
       return;
     }
     this.showError = false;
     this.search.emit({
       option: this.selectedOption.code,
-      query: this.inputValue.trim()
+      query: normalized
     });
   }
 

--- a/src/app/shared/interfaces/author.interface.ts
+++ b/src/app/shared/interfaces/author.interface.ts
@@ -50,7 +50,7 @@ export interface Link {
 export interface Coauthors {
   links: Link[]
   nodes: AuthorNode[]
-  affiliations: { scopusId: string, name: string }[]
+  affiliations: { scopus_id: string, name: string }[]
   total_results?: number
   page?: number
   page_size?: number


### PR DESCRIPTION
## Resumen
Adapta el frontend del buscador para consumir el contrato del microservicio v2 en
las piezas tocadas por los slices (en vez de llamar a v1 directo), en espejo con el
PR del backend.

## Cambios por slice
- **Slice 1 — Validación inmediata:** `search-box.component.ts` valida la consulta
  (regex de términos con sentido) y reutiliza el toast existente para el mensaje de
  error — defensa en profundidad con el `422` del backend.
- **Slice 2 — Perfil por composición:** `author.service.ts` consume
  `GET /v2/authors/{id}/profile` (con caché por id) y deriva coautores/topics/años
  de esa única respuesta → **0 llamadas directas a `/api-se/v1/` en el perfil**.
- **Slice 3-C — Contrato uniforme:** el grafo de autores relevantes, la página de
  artículo y la interfaz de autor usan `scopus_id` (no `scopusId`), alineados con el
  ACL del backend.

## Alcance
6 archivos, +42 / −23. Solo toca componentes del buscador (`search-box`,
`author.service`, `most-relevant-authors-graph`, `article-page`, interfaz de autor);
no afecta otros módulos.

Generated with [Claude Code](https://claude.com/claude-code)