### PR TITLE
Buscador: consumo del contrato v2 (slices 1–3) + UX (filtro, descarga del grafo, exportar zona)

### DIFF
--- a/src/app/search-engine/domain/services/author.service.ts
+++ b/src/app/search-engine/domain/services/author.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { map, Observable } from 'rxjs';
+import { map, Observable, shareReplay } from 'rxjs';
 import {HttpClient, HttpParams} from '@angular/common/http';
 import {
   Author,
@@ -26,6 +26,21 @@ export class AuthorService {
   rootURL: string = environment.apiCentinela;
   // dashURL: string = environment.apiDashboard;
 
+  // Slice 2 (API Composition): cache por autor del perfil compuesto. shareReplay
+  // hace que las multiples secciones (coautores, topics, anios) que consumen
+  // distintos componentes compartan UNA sola peticion a /v2/authors/{id}/profile.
+  private profileCache = new Map<string, Observable<any>>();
+
+  getAuthorProfile(id: string | number): Observable<any> {
+    const key = id.toString();
+    if (!this.profileCache.has(key)) {
+      this.profileCache.set(
+        key,
+        this.http.get<any>(`${this.rootURL}/v2/authors/${key}/profile`).pipe(shareReplay(1))
+      );
+    }
+    return this.profileCache.get(key)!;
+  }
 
   constructor(private http: HttpClient) {}
 
@@ -60,7 +75,8 @@ export class AuthorService {
   }
 
   getCoauthorsById(id: number): Observable<CoauthorInfo> {
-    return this.http.get<CoauthorInfo>(`${this.rootURL}/v1/coauthors/coauthors/${id}/coauthors_by_id/`);
+    // Slice 2: deriva de la composicion v2 en vez de llamar directo a v1.
+    return this.getAuthorProfile(id).pipe(map(p => p.coauthors as CoauthorInfo));
   }
 
   getMostRelevantAuthors(
@@ -104,20 +120,18 @@ export class AuthorService {
     return this.http.get<RandItem[]>(`${this.rootURL}random-topics`);
   }
   getTopicsById(scopus_id:number): Observable<NameValue[]> {
-    let params = new HttpParams().set('scopus_id', scopus_id.toString());
-    return this.http.get<Word[]>(`${this.rootURL}/v1/dashboard/author/get_topics/`, {params}).pipe(
-      map(response => {
-        const series: NameValue[] = response.map(t => ({
-          name: t.text.toString(),
-          value: t.size
-        }));
-        return series
-      }));
+    // Slice 2: las topics ahora vienen de la composicion v2 (misma forma {text,size}).
+    return this.getAuthorProfile(scopus_id).pipe(
+      map(p => ((p.topics || []) as Word[]).map(t => ({
+        name: t.text.toString(),
+        value: t.size
+      })))
+    );
   }
 
   getYears(scopus_id: string): Observable<AuthorYears[]> {
-    let params = new HttpParams().set('scopus_id', scopus_id.toString())
-    return this.http.get<AuthorYears[]>(`${this.rootURL}/v1/dashboard/author/get_author_years/`, {params});
+    // Slice 2: los anios ahora vienen de la composicion v2.
+    return this.getAuthorProfile(scopus_id).pipe(map(p => (p.years || []) as AuthorYears[]));
   }
 
   getLineChartInfo(scopus_id:string, name: string): Observable<LineChartInfo[]> {

--- a/src/app/search-engine/presentation/home-page/components/article-information/article-information.component.html
+++ b/src/app/search-engine/presentation/home-page/components/article-information/article-information.component.html
@@ -1,6 +1,6 @@
 <div class="flex flex-col md:flex-row justify-center gap-6 items-start mt-4 w-full px-4 xl:px-8">
   <div class="md:w-72 w-full flex-shrink-0">
-    <app-filters-sidebar [isFirstLoad]="isFirstLoad" [isLoading]="isFiltering" [isDisabled]="total === 0 && !isFirstLoad && !isFiltering && !isPaginating">
+    <app-filters-sidebar [isFirstLoad]="isFirstLoad" [isLoading]="isFiltering">
       <!-- Years -->
       <div class="py-2 px-4 font-semibold border-b border-gray-200 text-gray-700 bg-gray-50 text-sm tracking-wide">
         Publication year

--- a/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.html
+++ b/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.html
@@ -38,8 +38,9 @@
 
   <div class="flex-1 w-full flex flex-col">
     <div class="flex flex-col justify-between w-full bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden">
-      <div *ngIf="!showGraph" class="w-full min-w-full md:min-w-[800px]">
-        <app-loader [rows]="10"></app-loader>
+      <div *ngIf="!showGraph" class="w-full h-[600px] md:h-[800px] flex flex-col items-center justify-center gap-4 bg-white">
+        <div class="w-12 h-12 border-4 border-gray-200 border-t-red-600 rounded-full animate-spin"></div>
+        <span class="text-gray-500 text-sm">Cargando grafo de autores…</span>
       </div>
       <ng-container *ngIf="showGraph && !noResults">
         <div class="flex flex-row justify-between items-center w-full p-4 bg-white border-b border-gray-200">
@@ -47,12 +48,20 @@
             <div class="flex items-center gap-2"><span class="font-bold text-gray-900">Nodes:</span> <span class="bg-gray-100 px-3 py-1 rounded-full text-sm font-semibold">{{d3Nodes.length}}</span></div>
             <div class="flex items-center gap-2"><span class="font-bold text-gray-900">Relations:</span> <span class="bg-gray-100 px-3 py-1 rounded-full text-sm font-semibold">{{d3Links.length}}</span></div>
           </div>
-          <button type="button" class="bg-red-700 hover:bg-red-800 text-white py-2 px-4 rounded-lg shadow-sm flex items-center gap-2 transition-colors font-medium text-sm"
-                  (click)="onDownloadGraph()"
-                  *ngIf="d3Nodes.length > 0;">
-            <fa-icon [icon]="faDownload"></fa-icon>
-            Download
-          </button>
+          <div class="flex items-center gap-2" *ngIf="d3Nodes.length > 0;">
+            <button type="button" class="bg-red-700 hover:bg-red-800 text-white py-2 px-4 rounded-lg shadow-sm flex items-center gap-2 transition-colors font-medium text-sm"
+                    (click)="onDownloadGraph()" [disabled]="selectingRegion">
+              <fa-icon [icon]="faDownload"></fa-icon>
+              Descargar todo
+            </button>
+            <button type="button"
+                    class="border border-red-700 py-2 px-4 rounded-lg shadow-sm flex items-center gap-2 transition-colors font-medium text-sm"
+                    [ngClass]="selectingRegion ? 'bg-red-700 text-white' : 'text-red-700 hover:bg-red-50'"
+                    (click)="toggleRegionSelect()">
+              <fa-icon [icon]="faVectorSquare"></fa-icon>
+              {{ selectingRegion ? 'Cancelar' : 'Seleccionar zona' }}
+            </button>
+          </div>
         </div>
       </ng-container>
     </div>
@@ -64,13 +73,28 @@
     <div class="w-full max-w-full overflow-hidden mt-4 mat-elevation-z8" *ngIf="showGraph && !noResults">
       <div class="w-full h-[600px] md:h-[800px] overflow-hidden bg-white rounded relative" #downloadEl>
         
-        <!-- Zoom Controls Overlay -->
-        <div class="absolute top-4 right-4 z-10 flex flex-col gap-2">
+        <!-- Zoom Controls Overlay (z-30 para quedar sobre el overlay de seleccion y seguir clickeables) -->
+        <div class="absolute top-4 right-4 z-30 flex flex-col gap-2">
           <button (click)="zoomIn()" class="bg-white border shadow-md w-10 h-10 rounded-full flex items-center justify-center hover:bg-gray-100 text-2xl font-bold text-gray-700 select-none">+</button>
           <button (click)="zoomOut()" class="bg-white border shadow-md w-10 h-10 rounded-full flex items-center justify-center hover:bg-gray-100 text-2xl font-bold text-gray-700 select-none">-</button>
           <button (click)="resetZoom()" class="bg-white border shadow-md w-10 h-10 rounded-full flex items-center justify-center hover:bg-gray-100 text-gray-700 mt-2" title="Center">
             <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor"><path d="M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Zm40 360q-134 0-227-93T160-400q0-134 93-227t227-93q134 0 227 93t93 227q0 134-93 227t-227 93Zm0-80q100 0 170-70t70-170q0-100-70-170t-170-70q-100 0-170 70t-70 170q0 100 70 170t170 70Zm0-240Z"/></svg>
           </button>
+        </div>
+
+        <!-- Overlay de seleccion de zona: arrastrar para recortar y exportar solo esa parte -->
+        <div *ngIf="selectingRegion" class="absolute inset-0 z-20 cursor-crosshair select-none"
+             (mousedown)="onRegionMouseDown($event)"
+             (mousemove)="onRegionMouseMove($event)"
+             (mouseup)="onRegionMouseUp()"
+             (mouseleave)="onRegionMouseUp()">
+          <div *ngIf="!regionRect" class="absolute top-3 left-1/2 -translate-x-1/2 text-white text-xs px-3 py-1 rounded-full whitespace-nowrap" style="background: rgba(0,0,0,0.7)">
+            Arrastra para seleccionar la zona a descargar
+          </div>
+          <div *ngIf="regionRect" class="absolute border-2 border-red-600 pointer-events-none"
+               [style.left.px]="regionRect.x" [style.top.px]="regionRect.y"
+               [style.width.px]="regionRect.w" [style.height.px]="regionRect.h"
+               [style.background]="'rgba(220,38,38,0.12)'"></div>
         </div>
 
         <graph [nodes]="d3Nodes" [links]="d3Links" [forces]="forces"></graph>

--- a/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.html
+++ b/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.html
@@ -24,13 +24,13 @@
     <div class="py-3 px-4 flex md:flex-col gap-3 max-h-96 overflow-y-auto bg-white" *ngIf="affiliations && affiliations.length > 0">
       <div class="flex gap-3 items-center hover:bg-gray-50 p-1 rounded transition-colors" *ngFor="let aff of affiliations">
         <input
-          [id]="aff.scopusId"
+          [id]="aff.scopus_id"
           type="checkbox"
-          [checked]="selectedAffiliations.includes(aff.scopusId)"
+          [checked]="selectedAffiliations.includes(aff.scopus_id)"
           (change)="onClickCheckbox($any($event))"
           class="form-checkbox h-4 w-4 text-red-600 rounded border-gray-300 focus:ring-red-500 cursor-pointer"
         >
-        <label [for]="aff.scopusId" class="ml-2 text-sm text-gray-600 cursor-pointer flex-1 leading-tight">{{aff.name}}</label>
+        <label [for]="aff.scopus_id" class="ml-2 text-sm text-gray-600 cursor-pointer flex-1 leading-tight">{{aff.name}}</label>
       </div>
     </div>
   </app-filters-sidebar>

--- a/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.ts
+++ b/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.ts
@@ -28,7 +28,7 @@ export class MostRelevantAuthorsGraphComponent {
   showGraph: boolean = false
 
   authorsNumber: number = 50
-  affiliations!: { scopusId: string, name: string }[]
+  affiliations!: { scopus_id: string, name: string }[]
   selectedAffiliations: string[] = []
   noResults = false;
   isLoadingResults = false;
@@ -132,8 +132,8 @@ export class MostRelevantAuthorsGraphComponent {
   sortAffiliations() {
     if (this.affiliations) {
       this.affiliations.sort((a, b) => {
-        const aSelected = this.selectedAffiliations.includes(a.scopusId);
-        const bSelected = this.selectedAffiliations.includes(b.scopusId);
+        const aSelected = this.selectedAffiliations.includes(a.scopus_id);
+        const bSelected = this.selectedAffiliations.includes(b.scopus_id);
         if (aSelected && !bSelected) return -1;
         if (!aSelected && bSelected) return 1;
         return 0;

--- a/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.ts
+++ b/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.ts
@@ -1,7 +1,7 @@
 import {Component, ElementRef, EventEmitter, Inject, Input, Output, SimpleChanges, ViewChild} from "@angular/core";
 import {Link, Node} from "../../../../../shared/d3";
 import {AuthorNode, Coauthors} from "../../../../../shared/interfaces/author.interface";
-import {faDownload} from "@fortawesome/free-solid-svg-icons";
+import {faDownload, faVectorSquare} from "@fortawesome/free-solid-svg-icons";
 import {DOCUMENT} from "@angular/common";
 import {AuthorService} from "../../../../domain/services/author.service";
 import {catchError, EMPTY, of, tap} from "rxjs";
@@ -37,6 +37,12 @@ export class MostRelevantAuthorsGraphComponent {
 
   @ViewChild("downloadEl") downloadEl!: ElementRef;
   faDownload = faDownload
+  faVectorSquare = faVectorSquare
+
+  // Seleccion de zona para exportar solo una parte del grafo
+  selectingRegion = false
+  regionStart: { x: number, y: number } | null = null
+  regionRect: { x: number, y: number, w: number, h: number } | null = null
 
   constructor(private authorService: AuthorService,
               @Inject(DOCUMENT) private coreDoc: Document) {
@@ -246,9 +252,100 @@ export class MostRelevantAuthorsGraphComponent {
   }
 
   onDownloadGraph(): void {
-    const theElement = this.downloadEl.nativeElement;
-    htmlToImage.toPng(theElement).then(dataUrl => {
-      this.downloadDataUrl(dataUrl, `most-relevant-authors-graph-${this.query}`);
+    // Encajar el grafo COMPLETO en el viewport (fit-to-content) antes de capturar,
+    // para que la imagen muestre todo el grafo centrado y no un zoom recortado.
+    this.fitGraphToView(350);
+    setTimeout(() => {
+      // Capturar el <svg> del grafo (no el contenedor) evita el espacio en blanco
+      // sobrante (svg 600px dentro de un contenedor de 800px) y los botones de zoom.
+      // pixelRatio alto => etiquetas nitidas y legibles al ampliar la imagen.
+      const svgEl = this.downloadEl.nativeElement.querySelector('graph svg') as HTMLElement | null;
+      const target = svgEl ?? this.downloadEl.nativeElement;
+      htmlToImage.toPng(target, { pixelRatio: 3, backgroundColor: '#ffffff' }).then(dataUrl => {
+        this.downloadDataUrl(dataUrl, `most-relevant-authors-graph-${this.query}`);
+      });
+    }, 450); // espera a que termine la transicion del fit (350ms)
+  }
+
+  /** Calcula el bounding box real del grafo y ajusta zoom+pan para que entre
+   *  completo y centrado en el viewport (a diferencia de resetZoom, que aplica
+   *  un escalado fijo que puede recortar grafos dispersos). */
+  private fitGraphToView(durationMs: number): void {
+    const data = this.getSvgAndZoom();
+    if (!data || !data.zoom) return;
+    const container = data.svgEl.querySelector('g.my-border') as SVGGraphicsElement | null;
+    if (!container) return;
+    const bbox = container.getBBox(); // bbox del contenido en coords de la simulacion
+    if (!bbox.width || !bbox.height) return;
+    const vw = data.svgEl.clientWidth || 800;
+    const vh = data.svgEl.clientHeight || 600;
+    const scale = Math.min(Math.min(vw / bbox.width, vh / bbox.height) * 0.9, 1.5); // 0.9 = margen, tope 1.5x
+    const tx = vw / 2 - scale * (bbox.x + bbox.width / 2);
+    const ty = vh / 2 - scale * (bbox.y + bbox.height / 2);
+    data.svg.transition().duration(durationMs).call(
+      data.zoom.transform,
+      d3.zoomIdentity.translate(tx, ty).scale(scale)
+    );
+  }
+
+  // --- Seleccion de zona: arrastrar un rectangulo sobre el grafo y exportar solo ese recorte ---
+  toggleRegionSelect(): void {
+    this.selectingRegion = !this.selectingRegion;
+    this.regionStart = null;
+    this.regionRect = null;
+  }
+
+  private regionCoords(e: MouseEvent): { x: number, y: number } {
+    const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    return { x: e.clientX - r.left, y: e.clientY - r.top };
+  }
+
+  onRegionMouseDown(e: MouseEvent): void {
+    const p = this.regionCoords(e);
+    this.regionStart = p;
+    this.regionRect = { x: p.x, y: p.y, w: 0, h: 0 };
+  }
+
+  onRegionMouseMove(e: MouseEvent): void {
+    if (!this.regionStart) return;
+    const p = this.regionCoords(e);
+    this.regionRect = {
+      x: Math.min(this.regionStart.x, p.x),
+      y: Math.min(this.regionStart.y, p.y),
+      w: Math.abs(p.x - this.regionStart.x),
+      h: Math.abs(p.y - this.regionStart.y),
+    };
+  }
+
+  onRegionMouseUp(): void {
+    if (this.regionRect && this.regionRect.w > 5 && this.regionRect.h > 5) {
+      this.exportRegion(this.regionRect);
+      this.selectingRegion = false;
+    }
+    this.regionStart = null;
+    this.regionRect = null;
+  }
+
+  /** Exporta solo el rectangulo seleccionado (en coords del viewport del grafo) en alta resolucion. */
+  private exportRegion(rect: { x: number, y: number, w: number, h: number }): void {
+    const svgEl = this.downloadEl.nativeElement.querySelector('graph svg') as HTMLElement | null;
+    if (!svgEl) return;
+    const PR = 3; // pixelRatio: alta resolucion para que las etiquetas se lean
+    htmlToImage.toPng(svgEl, { pixelRatio: PR, backgroundColor: '#ffffff' }).then(dataUrl => {
+      const img = new Image();
+      img.onload = () => {
+        const canvas = this.coreDoc.createElement('canvas');
+        canvas.width = Math.max(1, Math.round(rect.w * PR));
+        canvas.height = Math.max(1, Math.round(rect.h * PR));
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return;
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        // recorta del PNG completo (svg) la region seleccionada (rect * pixelRatio)
+        ctx.drawImage(img, rect.x * PR, rect.y * PR, rect.w * PR, rect.h * PR, 0, 0, canvas.width, canvas.height);
+        this.downloadDataUrl(canvas.toDataURL('image/png'), `grafo-zona-${this.query}`);
+      };
+      img.src = dataUrl;
     });
   }
 

--- a/src/app/search-engine/presentation/home-page/pages/article-page/article-page.component.html
+++ b/src/app/search-engine/presentation/home-page/pages/article-page/article-page.component.html
@@ -23,7 +23,7 @@
             <ng-container *ngFor="let au of article?.authors">
               <span 
                 class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-50 text-red-700 cursor-pointer hover:bg-red-100 hover:shadow-sm transition-all border border-red-100" 
-                (click)="goToAuthor(au.scopusId)">
+                (click)="goToAuthor(au.scopus_id)">
                 <svg class="w-3.5 h-3.5 mr-1.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd"></path></svg>
                 {{ au.name }}
               </span>

--- a/src/app/shared/components/search-box/search-box.component.ts
+++ b/src/app/shared/components/search-box/search-box.component.ts
@@ -69,14 +69,19 @@ export class SearchBoxComponent implements OnInit{
   }
 
   triggerSearch() {
-    if (!this.inputValue || this.inputValue.trim() === '') {
+    const normalized = (this.inputValue || '').trim().replace(/\s\s+/g, ' ');
+    // Validacion espejo del agregado Consulta: mismo contrato que el 422
+    // CONTRACT_VALIDATION del microservicio v2. Requiere al menos un token
+    // alfabetico significativo (>= 2 letras); de lo contrario es semanticamente
+    // vacia. Da feedback inmediato y cierra el defecto UX-05 de Fase 1.
+    if (!normalized || !/\p{L}{2,}/u.test(normalized)) {
       this.showError = true;
       return;
     }
     this.showError = false;
     this.search.emit({
       option: this.selectedOption.code,
-      query: this.inputValue.trim()
+      query: normalized
     });
   }
 

--- a/src/app/shared/interfaces/author.interface.ts
+++ b/src/app/shared/interfaces/author.interface.ts
@@ -50,7 +50,7 @@ export interface Link {
 export interface Coauthors {
   links: Link[]
   nodes: AuthorNode[]
-  affiliations: { scopusId: string, name: string }[]
+  affiliations: { scopus_id: string, name: string }[]
   total_results?: number
   page?: number
   page_size?: number


### PR DESCRIPTION
## Consumo del contrato v2 (slices)
- **Slice 1:** validación inmediata de la consulta en `search-box` (defensa en profundidad con el 422 del backend).
- **Slice 2:** perfil de autor vía `GET /v2/authors/{id}/profile` (0 llamadas directas a `/api-se/v1/`).
- **Slice 3-C:** contrato uniforme `scopus_id` (grafo, página de artículo, interfaz de autor).

## Arreglos de UX
- **Filtro de año no se bloquea con 0 resultados:** el sidebar quedaba con `pointer-events-none` al filtrar y obtener 0 resultados, obligando a recargar; ahora sigue interactivo.
- **Descarga del grafo:** encaja el grafo completo (fit-to-content) y exporta en alta resolución (PNG 3×, captura del `<svg>`) → centrado, sin espacio en blanco ni botones, etiquetas legibles.
- **Loader del grafo:** spinner en vez del skeleton de tabla.

## Feature nueva
- **Exportar zona del grafo:** botón "Seleccionar zona" para arrastrar un rectángulo y descargar solo ese recorte en alta resolución; los botones de zoom siguen usables durante la selección (acercar y luego recortar).

## Nota
La faceta de años es global del corpus (no por consulta) → un año válido puede dar 0 resultados para una query concreta. Facetas por-consulta = mejora futura.

Generated with [Claude Code](https://claude.com/claude-code)