### PR TITLE
feat(buscador): perfil de autor público (Opción B) + mejoras de UI del detalle de autor y header

### DIFF
--- a/src/app/profile/presentation/components/article/article.component.html
+++ b/src/app/profile/presentation/components/article/article.component.html
@@ -1,8 +1,16 @@
 <div class="w-full flex flex-col gap-4 py-4 px-2">
-  <div class="bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden w-full">
+
+  <!-- Cargando -->
+  <div *ngIf="loading" class="flex justify-center items-center py-16">
+    <app-mini-loader size="10"></app-mini-loader>
+  </div>
+
+  <!-- Con datos -->
+  <div *ngIf="!loading && articles.length > 0"
+       class="bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden w-full">
     <table
       mat-table
-      [dataSource]="articles"
+      [dataSource]="pagedArticles"
       class="min-w-full"
     >
       <!-- Title Column -->
@@ -32,9 +40,26 @@
         class="hover:cursor-pointer hover:bg-gray-100 transition-colors"
       ></tr>
     </table>
-    
-    <div *ngIf="articles.length === 0" class="text-center py-10 bg-gray-50">
-      <p class="text-gray-500">No articles found for this author.</p>
+
+    <!-- Paginacion (en cliente) -->
+    <div *ngIf="articles.length > pageSize"
+         class="flex items-center justify-end gap-3 px-4 py-3 bg-white border-t border-gray-200">
+      <span class="text-sm text-gray-600">
+        Página <span class="font-bold text-red-700">{{ pageIndex + 1 }}</span> de {{ totalPages }}
+        <span class="text-gray-400">({{ articles.length }} artículos)</span>
+      </span>
+      <button type="button" (click)="prevPage()" [disabled]="pageIndex === 0"
+              class="px-3 py-1 rounded border border-gray-300 text-sm hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed">
+        Anterior
+      </button>
+      <button type="button" (click)="nextPage()" [disabled]="pageIndex >= totalPages - 1"
+              class="px-3 py-1 rounded border border-gray-300 text-sm hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed">
+        Siguiente
+      </button>
     </div>
   </div>
+
+  <!-- Sin datos -->
+  <app-no-results *ngIf="!loading && articles.length === 0"
+                  title="Este autor no tiene artículos registrados"></app-no-results>
 </div>

--- a/src/app/profile/presentation/components/article/article.component.ts
+++ b/src/app/profile/presentation/components/article/article.component.ts
@@ -17,6 +17,10 @@ export class ArticleComponent implements OnInit{
 
   idRoute!: string
   articles: ArticlesResponse[]= []
+  pagedArticles: ArticlesResponse[] = []
+  pageIndex = 0
+  pageSize = 10
+  loading = false
   private userSubscription: Subscription = new Subscription();
   user: User | null = null;
   // articles:
@@ -27,20 +31,13 @@ export class ArticleComponent implements OnInit{
     this.route.parent?.paramMap.subscribe(params => {
       this.idRoute = params?.get('id')!;
       if (this.isNumeric(this.idRoute)) {
-        this.authorService.getAuthorById(this.idRoute).subscribe(data => {
-          this.idRoute = data.scopus_id.toString()
-        })
-        this.authorService.getArticles(this.idRoute).subscribe(data=>{
-          this.articles = data
-        })
+        this.fetchArticles(this.idRoute)
       }else {
         this.userSubscription = this.userDataService.getUser().subscribe((user: User | null) => {
           this.user = user;
           if(this.user?.scopus_id){
             this.idRoute=this.user.scopus_id
-            this.authorService.getArticles(this.idRoute).subscribe(data=>{
-              this.articles = data
-            })
+            this.fetchArticles(this.idRoute)
           }
         });
       }
@@ -49,6 +46,42 @@ export class ArticleComponent implements OnInit{
   isNumeric(value: string): boolean {
     return /^\d+$/.test(value);
   }
+
+  private fetchArticles(id: string): void {
+    this.loading = true;
+    this.authorService.getArticles(id).subscribe({
+      next: data => {
+        this.articles = data || [];
+        this.pageIndex = 0;
+        this.updatePaged();
+        this.loading = false;
+      },
+      error: () => {
+        this.articles = [];
+        this.updatePaged();
+        this.loading = false;
+      }
+    });
+  }
+
+  // Paginacion en cliente (el endpoint devuelve todos los articulos del autor de una vez).
+  private updatePaged(): void {
+    const start = this.pageIndex * this.pageSize;
+    this.pagedArticles = this.articles.slice(start, start + this.pageSize);
+  }
+
+  get totalPages(): number {
+    return Math.max(1, Math.ceil(this.articles.length / this.pageSize));
+  }
+
+  prevPage(): void {
+    if (this.pageIndex > 0) { this.pageIndex--; this.updatePaged(); }
+  }
+
+  nextPage(): void {
+    if (this.pageIndex < this.totalPages - 1) { this.pageIndex++; this.updatePaged(); }
+  }
+
   seeMoreInformation(scopusId: string) {
     const url = this.router.serializeUrl(
       this.router.createUrlTree(['home/article', scopusId])

--- a/src/app/profile/presentation/components/fingerprint/fingerprint.component.html
+++ b/src/app/profile/presentation/components/fingerprint/fingerprint.component.html
@@ -1,4 +1,14 @@
-<div *ngIf="words.length > 1" class="flex justify-center items-center">
-<!--  <app-word-cloud [words]="words" [width]="1000" [height]="500" [x]="100" [y]="100" [size]="1" [padding]="0.5" [min]="400" ></app-word-cloud>-->
-  <app-tree-map-chart [width]="900" [height]="500" [topic]="true" [single]="words"></app-tree-map-chart>
+<!-- Cargando -->
+<div *ngIf="loading" class="flex justify-center items-center py-16">
+  <app-mini-loader size="10"></app-mini-loader>
 </div>
+
+<!-- Con datos -->
+<div *ngIf="!loading && words.length >= 1" class="flex justify-center items-center">
+<!--  <app-word-cloud [words]="words" [width]="1000" [height]="500" [x]="100" [y]="100" [size]="1" [padding]="0.5" [min]="400" ></app-word-cloud>-->
+  <app-tree-map-chart [width]="900" [height]="500" [topic]="true" [single]="words" [clickable]="false"></app-tree-map-chart>
+</div>
+
+<!-- Sin datos -->
+<app-no-results *ngIf="!loading && words.length === 0"
+                title="Este autor no tiene áreas temáticas registradas"></app-no-results>

--- a/src/app/profile/presentation/components/fingerprint/fingerprint.component.ts
+++ b/src/app/profile/presentation/components/fingerprint/fingerprint.component.ts
@@ -21,23 +21,23 @@ export class FingerprintComponent implements OnInit {
   user: User | null = null;
   // author!:Author
   scopusId!: number
-  words!: NameValue[]
+  words: NameValue[] = []
+  loading = false
 
   ngOnInit() {
     this.route.parent?.paramMap.subscribe(params => {
       let id = parseInt(params?.get('id')!);
       if(this.isNumeric(id.toString())){
         this.scopusId = id;
+        this.getTopics()
       }else{
         this.userSubscription = this.userDataService.getUser().subscribe((user: User | null) => {
           this.user = user;
           if (this.user?.scopus_id) {
             this.scopusId = parseInt(this.user.scopus_id)
+            this.getTopics()
           }
         });
-      }
-      if (this.scopusId) {
-        this.getTopics()
       }
     });
   }
@@ -46,11 +46,18 @@ export class FingerprintComponent implements OnInit {
   }
 
   getTopics() {
-    this.authorService.getTopicsById(this.scopusId).subscribe(
-      data => {
-        this.words = data
+    if (!this.scopusId) { return; }
+    this.loading = true;
+    this.authorService.getTopicsById(this.scopusId).subscribe({
+      next: data => {
+        this.words = data || [];
+        this.loading = false;
+      },
+      error: () => {
+        this.words = [];
+        this.loading = false;
       }
-    )
+    })
   }
 
 

--- a/src/app/profile/presentation/components/network/network.component.html
+++ b/src/app/profile/presentation/components/network/network.component.html
@@ -1,3 +1,13 @@
-<div class="px-10 pb-10" *ngIf="author">
-  <app-coauthors-graph [author]="author"></app-coauthors-graph>
+<div class="px-10 pb-10">
+  <!-- Cargando -->
+  <div *ngIf="loading" class="flex justify-center items-center py-16">
+    <app-mini-loader size="10"></app-mini-loader>
+  </div>
+
+  <!-- Con datos -->
+  <app-coauthors-graph *ngIf="!loading && author" [author]="author"></app-coauthors-graph>
+
+  <!-- Sin datos -->
+  <app-no-results *ngIf="!loading && !author"
+                  title="No se pudo cargar la red de coautores de este autor"></app-no-results>
 </div>

--- a/src/app/profile/presentation/components/network/network.component.ts
+++ b/src/app/profile/presentation/components/network/network.component.ts
@@ -15,11 +15,11 @@ export class NetworkComponent implements OnInit {
 
   author: Author | undefined;
   scopusId!: number;
+  loading = false;
   private userSubscription: Subscription = new Subscription();
   user: User | null = null;
 
   constructor(private route: ActivatedRoute, private authorService: AuthorService, private userDataService: UserDataService) {
-    console.log(this.author)
   }
 
   ngOnInit(): void {
@@ -27,16 +27,15 @@ export class NetworkComponent implements OnInit {
       let id = parseInt(params?.get('id')!);
       if(this.isNumeric(id.toString())){
         this.scopusId = id;
+        this.getAuthor();
       }else{
         this.userSubscription = this.userDataService.getUser().subscribe((user: User | null) => {
           this.user = user;
           if (this.user?.scopus_id) {
             this.scopusId = parseInt(this.user.scopus_id)
+            this.getAuthor();
           }
         });
-      }
-      if (this.scopusId) {
-        this.getAuthor();
       }
     });
   }
@@ -47,14 +46,17 @@ export class NetworkComponent implements OnInit {
 
   getAuthor(): void {
     if (this.scopusId) {
-      this.authorService.getAuthorById(this.scopusId.toString()).subscribe(
-        data => {
+      this.loading = true;
+      this.authorService.getAuthorById(this.scopusId.toString()).subscribe({
+        next: data => {
           this.author = data;
+          this.loading = false;
         },
-        error => {
+        error: error => {
           console.error('Error fetching author', error);
+          this.loading = false;
         }
-      );
+      });
     }
   }
 }

--- a/src/app/profile/presentation/pages/profile-page/profile.component.html
+++ b/src/app/profile/presentation/pages/profile-page/profile.component.html
@@ -6,11 +6,11 @@
   <div class="bg-gray-50">
     <app-profile-data [user]="user!" [authorCentinela]="authorCentinela" [isOwnProfile]="isOwnProfile"></app-profile-data>
   </div>
-  <div class="bg-slate-200 border-y border-gray-200">
+  <div class="bg-slate-200 border-y border-gray-200 scroll-mt-20" #tabsTop>
     <app-data-nav [user]="user" [isOwnProfile]="isOwnProfile"  [authorCentinela]="authorCentinela"></app-data-nav>
   </div>
   <div class="bg-gray-100">
-    <div class="container mx-auto max-w-screen-xl px-3 pt-4">
+    <div class="container mx-auto max-w-screen-xl px-3 pt-4 pb-8">
       <router-outlet ></router-outlet>
     </div>
   </div>

--- a/src/app/profile/presentation/pages/profile-page/profile.component.ts
+++ b/src/app/profile/presentation/pages/profile-page/profile.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { Component, OnInit, OnDestroy, ElementRef, ViewChild } from '@angular/core';
+import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
+import { filter } from 'rxjs/operators';
 import { AuthService } from 'src/app/auth/domain/services/auth.service';
 import { UserService } from 'src/app/profile/domain/services/user.service';
 import { Subscription } from 'rxjs';
@@ -23,13 +24,16 @@ export class ProfileComponent implements OnInit, OnDestroy {
   editModalVisible: boolean = false;
   postToEdit: any = null;
 
+  @ViewChild('tabsTop') tabsTop?: ElementRef;
+
   constructor(
     private route: ActivatedRoute,
     private userService: UserService,
     private authService: AuthService,
     private userDataService: UserDataService,
     private titleService: Title,
-    private authorService: AuthorService
+    private authorService: AuthorService,
+    private router: Router
   ) { }
 
   ngOnInit(): void {
@@ -37,6 +41,21 @@ export class ProfileComponent implements OnInit, OnDestroy {
       this.userId = params['id'];
       this.loadUserData();
     });
+
+    // Al cambiar entre pestanas (network/article/fingerprint/...) el alto del
+    // contenido cambia y el navegador deja el scroll donde estaba, lo que se
+    // percibe como un "salto". Llevamos la vista al inicio de la barra de
+    // pestanas para que el cambio de alto ocurra fuera del area visible.
+    this.routeSub.add(
+      this.router.events
+        .pipe(filter(e => e instanceof NavigationEnd))
+        .subscribe((e) => {
+          const url = (e as NavigationEnd).urlAfterRedirects;
+          if (/\/(network|article|fingerprint|about-me|my-groups)(\/|$|\?)/.test(url)) {
+            this.tabsTop?.nativeElement?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+          }
+        })
+    );
   }
 
   ngOnDestroy(): void {
@@ -49,6 +68,15 @@ export class ProfileComponent implements OnInit, OnDestroy {
    * Carga los datos del usuario si están disponibles, de lo contrario, carga los datos del autor.
    */
   private loadUserData(): void {
+    // Vista publica de autor (Opcion B): si el id es un scopus_id numerico (un autor
+    // proveniente del buscador), se carga el detalle academico publico directamente.
+    // Asi se evita la llamada autenticada a userService, que para un usuario SIN sesion
+    // provoca un 401 y la redireccion a login. Las pestanas (network/article/fingerprint)
+    // ya resuelven el autor por scopus_id contra la API publica del microservicio v2.
+    if (/^\d+$/.test(String(this.userId))) {
+      this.loadAuthorData();
+      return;
+    }
     this.userService.getUserById(this.userId).subscribe({
       next: (data: UserProfile) => {
         this.user = { ...data, id: this.userId, isOwnProfile: this.isOwnProfile };

--- a/src/app/search-engine/presentation/home-page/components/coauthors-graph/coauthors-graph.component.html
+++ b/src/app/search-engine/presentation/home-page/components/coauthors-graph/coauthors-graph.component.html
@@ -1,18 +1,74 @@
-<ng-container *ngIf="showGraph">
+<!-- Cargando -->
+<div *ngIf="loading" class="flex justify-center items-center py-16">
+  <app-mini-loader size="10"></app-mini-loader>
+</div>
 
-  <div class="d-flex flex-wrap justify-content-between align-items-center pb-4 gap-3">
-    <div class="d-flex flex-column">
-      <div><b>Nodos/Autores:</b> {{d3Nodes.length}}</div>
-      <div><b>Relaciones:</b> {{d3Links.length}}</div>
+<!-- Sin coautores -->
+<app-no-results *ngIf="!loading && !showGraph"
+                title="Este autor no tiene coautores registrados"></app-no-results>
+
+<div *ngIf="showGraph" class="flex-1 w-full flex flex-col">
+
+  <!-- Barra superior: conteos + acciones -->
+  <div class="flex flex-col justify-between w-full bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden">
+    <div class="flex flex-row flex-wrap justify-between items-center w-full p-4 bg-white border-b border-gray-200 gap-3">
+      <div class="flex items-center gap-6 text-gray-700">
+        <div class="flex items-center gap-2">
+          <span class="font-bold text-gray-900">Nodos/Autores:</span>
+          <span class="bg-gray-100 px-3 py-1 rounded-full text-sm font-semibold">{{d3Nodes.length}}</span>
+        </div>
+        <div class="flex items-center gap-2">
+          <span class="font-bold text-gray-900">Relaciones:</span>
+          <span class="bg-gray-100 px-3 py-1 rounded-full text-sm font-semibold">{{d3Links.length}}</span>
+        </div>
+      </div>
+      <div class="flex items-center gap-2" *ngIf="d3Nodes.length > 0;">
+        <button type="button"
+                class="bg-red-700 hover:bg-red-800 text-white py-2 px-4 rounded-lg shadow-sm flex items-center gap-2 transition-colors font-medium text-sm"
+                (click)="onDownloadGraph()" [disabled]="selectingRegion">
+          <fa-icon [icon]="faDownload"></fa-icon>
+          Descargar todo
+        </button>
+        <button type="button"
+                class="border border-red-700 py-2 px-4 rounded-lg shadow-sm flex items-center gap-2 transition-colors font-medium text-sm"
+                [ngClass]="selectingRegion ? 'bg-red-700 text-white' : 'text-red-700 hover:bg-red-50'"
+                (click)="toggleRegionSelect()">
+          <fa-icon [icon]="faVectorSquare"></fa-icon>
+          {{ selectingRegion ? 'Cancelar' : 'Seleccionar zona' }}
+        </button>
+      </div>
     </div>
-    <button type="button" class="btn bg-primary_tailwind text-white hover:bg-blue-500" (click)="onDownloadGraph()">
-      <fa-icon [icon]="faDownload"></fa-icon>
-      Descargar
-    </button>
   </div>
 
-  <div class="d-flex justify-content-center text-truncate graph" #downloadEl>
-    <graph [nodes]="d3Nodes" [links]="d3Links" [forces]="forces"></graph>
-  </div>
-</ng-container>
+  <!-- Grafo -->
+  <div class="w-full max-w-full overflow-hidden mt-4 mat-elevation-z8">
+    <div class="w-full h-[600px] md:h-[800px] overflow-hidden bg-white rounded relative" #downloadEl>
 
+      <!-- Controles de zoom (z-30 para quedar sobre el overlay de seleccion) -->
+      <div class="absolute top-4 right-4 z-30 flex flex-col gap-2">
+        <button (click)="zoomIn()" class="bg-white border shadow-md w-10 h-10 rounded-full flex items-center justify-center hover:bg-gray-100 text-2xl font-bold text-gray-700 select-none">+</button>
+        <button (click)="zoomOut()" class="bg-white border shadow-md w-10 h-10 rounded-full flex items-center justify-center hover:bg-gray-100 text-2xl font-bold text-gray-700 select-none">-</button>
+        <button (click)="resetZoom()" class="bg-white border shadow-md w-10 h-10 rounded-full flex items-center justify-center hover:bg-gray-100 text-gray-700 mt-2" title="Centrar">
+          <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor"><path d="M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Zm40 360q-134 0-227-93T160-400q0-134 93-227t227-93q134 0 227 93t93 227q0 134-93 227t-227 93Zm0-80q100 0 170-70t70-170q0-100-70-170t-170-70q-100 0-170 70t-70 170q0 100 70 170t170 70Zm0-240Z"/></svg>
+        </button>
+      </div>
+
+      <!-- Overlay de seleccion de zona: arrastrar para recortar y exportar solo esa parte -->
+      <div *ngIf="selectingRegion" class="absolute inset-0 z-20 cursor-crosshair select-none"
+           (mousedown)="onRegionMouseDown($event)"
+           (mousemove)="onRegionMouseMove($event)"
+           (mouseup)="onRegionMouseUp()"
+           (mouseleave)="onRegionMouseUp()">
+        <div *ngIf="!regionRect" class="absolute top-3 left-1/2 -translate-x-1/2 text-white text-xs px-3 py-1 rounded-full whitespace-nowrap" style="background: rgba(0,0,0,0.7)">
+          Arrastra para seleccionar la zona a descargar
+        </div>
+        <div *ngIf="regionRect" class="absolute border-2 border-red-600 pointer-events-none"
+             [style.left.px]="regionRect.x" [style.top.px]="regionRect.y"
+             [style.width.px]="regionRect.w" [style.height.px]="regionRect.h"
+             [style.background]="'rgba(220,38,38,0.12)'"></div>
+      </div>
+
+      <graph [nodes]="d3Nodes" [links]="d3Links" [forces]="forces"></graph>
+    </div>
+  </div>
+</div>

--- a/src/app/search-engine/presentation/home-page/components/coauthors-graph/coauthors-graph.component.ts
+++ b/src/app/search-engine/presentation/home-page/components/coauthors-graph/coauthors-graph.component.ts
@@ -1,6 +1,6 @@
 import {Component, ElementRef, Inject, Input, ViewChild} from '@angular/core';
 
-import {faDownload} from '@fortawesome/free-solid-svg-icons';
+import {faDownload, faVectorSquare} from '@fortawesome/free-solid-svg-icons';
 import {DOCUMENT} from '@angular/common';
 import {
   Author,
@@ -9,6 +9,7 @@ import {
 import {Node, Link} from '../../../../../shared/d3';
 import {AuthorService} from '../../../../domain/services/author.service';
 import * as htmlToImage from 'html-to-image';
+import * as d3 from 'd3';
 
 @Component({
   selector: 'app-coauthors-graph',
@@ -30,9 +31,16 @@ export class CoauthorsGraphComponent {
   };
 
   showGraph: boolean = false;
+  loading: boolean = false;
 
   @ViewChild('downloadEl') downloadEl!: ElementRef;
   faDownload = faDownload;
+  faVectorSquare = faVectorSquare;
+
+  // Seleccion de zona para exportar solo una parte del grafo
+  selectingRegion = false;
+  regionStart: { x: number, y: number } | null = null;
+  regionRect: { x: number, y: number, w: number, h: number } | null = null;
 
   constructor(
     private authorService: AuthorService,
@@ -43,20 +51,31 @@ export class CoauthorsGraphComponent {
   }
 
   ngOnInit() {
+    this.loading = true;
     this.authorService
       .getCoauthorsById(this.author.scopus_id)
-      .subscribe(coauthors => {
-        this.apiNodes = coauthors.data.nodes;
-        this.apiNodes.push({
-          scopus_id: parseInt(String(this.author.scopus_id)),
-          initials: this.author.initials,
-          first_name: this.author.first_name,
-          last_name: this.author.last_name,
-          weight: 0,
-        });
-        this.setupNodes();
-        this.setupLinks(coauthors.data.links);
-        this.showGraph = true;
+      .subscribe({
+        next: coauthors => {
+          this.apiNodes = coauthors.data.nodes || [];
+          // Si el autor no tiene coautores reales solo quedaria su propio nodo
+          // suelto; en ese caso mostramos un mensaje en vez de un grafo vacio.
+          const hasCoauthors = this.apiNodes.length > 0;
+          this.apiNodes.push({
+            scopus_id: parseInt(String(this.author.scopus_id)),
+            initials: this.author.initials,
+            first_name: this.author.first_name,
+            last_name: this.author.last_name,
+            weight: 0,
+          });
+          this.setupNodes();
+          this.setupLinks(coauthors.data.links);
+          this.showGraph = hasCoauthors;
+          this.loading = false;
+        },
+        error: () => {
+          this.showGraph = false;
+          this.loading = false;
+        }
       });
   }
 
@@ -128,9 +147,129 @@ export class CoauthorsGraphComponent {
   }
 
   onDownloadGraph(): void {
-    const theElement = this.downloadEl.nativeElement;
-    htmlToImage.toPng(theElement).then((dataUrl) => {
-      this.downloadDataUrl(dataUrl, `coauthor-graph-${this.author.scopus_id}`);
+    // Encaja el grafo completo (fit-to-content) y captura el <svg> a alta resolucion,
+    // para que la imagen salga centrada y con etiquetas legibles (mejora portada del
+    // grafo de Relevant Authors).
+    this.fitGraphToView(350);
+    setTimeout(() => {
+      const svgEl = this.downloadEl.nativeElement.querySelector('graph svg') as HTMLElement | null;
+      const target = svgEl ?? this.downloadEl.nativeElement;
+      htmlToImage.toPng(target, {pixelRatio: 3, backgroundColor: '#ffffff'}).then((dataUrl) => {
+        this.downloadDataUrl(dataUrl, `coauthor-graph-${this.author.scopus_id}`);
+      });
+    }, 450);
+  }
+
+  private getSvgAndZoom() {
+    if (!this.downloadEl) return null;
+    const svgEl = this.downloadEl.nativeElement.querySelector('graph svg');
+    if (!svgEl) return null;
+    return {svg: d3.select(svgEl), zoom: (svgEl as any).__zoomBehavior, svgEl};
+  }
+
+  /** Mide el bounding box real del grafo y ajusta zoom+pan para que entre completo y centrado. */
+  private fitGraphToView(durationMs: number): void {
+    const data = this.getSvgAndZoom();
+    if (!data || !data.zoom) return;
+    const container = data.svgEl.querySelector('g.my-border') as SVGGraphicsElement | null;
+    if (!container) return;
+    const bbox = container.getBBox();
+    if (!bbox.width || !bbox.height) return;
+    const vw = data.svgEl.clientWidth || 800;
+    const vh = data.svgEl.clientHeight || 600;
+    const scale = Math.min(Math.min(vw / bbox.width, vh / bbox.height) * 0.9, 1.5);
+    const tx = vw / 2 - scale * (bbox.x + bbox.width / 2);
+    const ty = vh / 2 - scale * (bbox.y + bbox.height / 2);
+    data.svg.transition().duration(durationMs).call(
+      data.zoom.transform,
+      d3.zoomIdentity.translate(tx, ty).scale(scale)
+    );
+  }
+
+  // --- Seleccion de zona: arrastrar un rectangulo sobre el grafo y exportar solo ese recorte ---
+  toggleRegionSelect(): void {
+    this.selectingRegion = !this.selectingRegion;
+    this.regionStart = null;
+    this.regionRect = null;
+  }
+
+  private regionCoords(e: MouseEvent): { x: number, y: number } {
+    const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    return { x: e.clientX - r.left, y: e.clientY - r.top };
+  }
+
+  onRegionMouseDown(e: MouseEvent): void {
+    const p = this.regionCoords(e);
+    this.regionStart = p;
+    this.regionRect = { x: p.x, y: p.y, w: 0, h: 0 };
+  }
+
+  onRegionMouseMove(e: MouseEvent): void {
+    if (!this.regionStart) return;
+    const p = this.regionCoords(e);
+    this.regionRect = {
+      x: Math.min(this.regionStart.x, p.x),
+      y: Math.min(this.regionStart.y, p.y),
+      w: Math.abs(p.x - this.regionStart.x),
+      h: Math.abs(p.y - this.regionStart.y),
+    };
+  }
+
+  onRegionMouseUp(): void {
+    if (this.regionRect && this.regionRect.w > 5 && this.regionRect.h > 5) {
+      this.exportRegion(this.regionRect);
+      this.selectingRegion = false;
+    }
+    this.regionStart = null;
+    this.regionRect = null;
+  }
+
+  /** Exporta solo el rectangulo seleccionado (en coords del viewport del grafo) en alta resolucion. */
+  private exportRegion(rect: { x: number, y: number, w: number, h: number }): void {
+    const svgEl = this.downloadEl.nativeElement.querySelector('graph svg') as HTMLElement | null;
+    if (!svgEl) return;
+    const PR = 3; // pixelRatio: alta resolucion para que las etiquetas se lean
+    htmlToImage.toPng(svgEl, { pixelRatio: PR, backgroundColor: '#ffffff' }).then(dataUrl => {
+      const img = new Image();
+      img.onload = () => {
+        const canvas = this.coreDoc.createElement('canvas');
+        canvas.width = Math.max(1, Math.round(rect.w * PR));
+        canvas.height = Math.max(1, Math.round(rect.h * PR));
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return;
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.drawImage(img, rect.x * PR, rect.y * PR, rect.w * PR, rect.h * PR, 0, 0, canvas.width, canvas.height);
+        this.downloadDataUrl(canvas.toDataURL('image/png'), `grafo-zona-${this.author.scopus_id}`);
+      };
+      img.src = dataUrl;
     });
+  }
+
+  // --- Controles de zoom ---
+  zoomIn(): void {
+    const data = this.getSvgAndZoom();
+    if (data && data.zoom) {
+      data.svg.transition().duration(300).call(data.zoom.scaleBy, 1.3);
+    }
+  }
+
+  zoomOut(): void {
+    const data = this.getSvgAndZoom();
+    if (data && data.zoom) {
+      data.svg.transition().duration(300).call(data.zoom.scaleBy, 0.7);
+    }
+  }
+
+  resetZoom(): void {
+    const data = this.getSvgAndZoom();
+    if (data && data.zoom) {
+      const width = data.svgEl.clientWidth || 800;
+      const height = data.svgEl.clientHeight || 600;
+      data.svg.transition().duration(750).call(
+        data.zoom.transform,
+        d3.zoomIdentity.translate(width / 2, height / 2).scale(0.3).translate(-width / 2, -height / 2)
+      );
+    }
   }
 }

--- a/src/app/shared/components/header/header.component.css
+++ b/src/app/shared/components/header/header.component.css
@@ -542,27 +542,11 @@
   box-shadow: 0 0 0 3px rgba(30, 60, 139, 0.3);
 }
 
-/* ===== DARK MODE SUPPORT ===== */
-@media (prefers-color-scheme: dark) {
-  .nav-link {
-    color: #f9fafb;
-  }
-  
-  .nav-link:hover {
-    background-color: rgba(255, 255, 255, 0.1);
-  }
-  
-  .search-input {
-    background-color: rgba(255, 255, 255, 0.1);
-    border-color: rgba(255, 255, 255, 0.2);
-    color: white;
-  }
-  
-  .search-dropdown {
-    background-color: rgba(30, 41, 59, 0.95);
-    border-color: rgba(255, 255, 255, 0.1);
-  }
-}
+/* La barra de navegacion siempre es una superficie clara (bg-white/95), por lo que
+   NO debe seguir el modo oscuro del sistema: hacerlo dejaba el texto casi-blanco
+   sobre fondo blanco y las tabs (Home/Analytics/About) quedaban invisibles salvo
+   al hacer hover o cuando estaban activas. El resto de la app tampoco soporta dark
+   mode, asi que se elimina ese bloque @media prefers-color-scheme: dark. */
 
 /* ===== USER DROPDOWN STYLES ===== */
 .nav-item.relative {
@@ -632,10 +616,26 @@
 }
 
 .chevron-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 0.75rem;
   height: 0.75rem;
-  transition: transform 0.2s ease;
   margin-left: 0.5rem;
+  line-height: 0;
+  transition: transform 0.2s ease;
+  /* Gira sobre su propio centro (antes parecia describir un semicirculo porque
+     el <svg> de FontAwesome tiene vertical-align y el origen quedaba descentrado). */
+  transform-origin: center center;
+}
+
+/* El <svg> que renderiza fa-icon debe llenar y centrarse en la caja del chevron,
+   de lo contrario el glifo queda desfasado respecto al centro de rotacion. */
+.chevron-icon ::ng-deep svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  vertical-align: middle;
 }
 
 .nav-link-user-button:hover .user-icon {

--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -46,13 +46,13 @@
           </a>
         </div> <!-- Analytics -->
         <div class="nav-item" *ngIf="showInformation">
-          <a routerLink="./analitica" routerLinkActive="active" class="nav-link">
+          <a routerLink="/home/analitica" routerLinkActive="active" class="nav-link">
             <fa-icon [icon]="faChartBar" class="nav-icon"></fa-icon>
             <span>Analytics</span>
           </a>
         </div> <!-- About -->
         <div class="nav-item" *ngIf="showInformation">
-          <a routerLink="./about-us/getting-started" routerLinkActive="active" class="nav-link">
+          <a routerLink="/home/about-us/getting-started" routerLinkActive="active" class="nav-link">
             <fa-icon [icon]="faInfoCircle" class="nav-icon"></fa-icon>
             <span>About</span>
           </a>

--- a/src/app/shared/components/visuals/tree-map-chart/tree-map-chart.component.css
+++ b/src/app/shared/components/visuals/tree-map-chart/tree-map-chart.component.css
@@ -1,0 +1,7 @@
+/* Cuando el tree-map NO es interactivo (clickable=false), sus recuadros muestran el
+   cursor por defecto en vez del de mano (que sugiere que son clickeables). Va scoped a
+   :host.tm-static para NO afectar a los tree-maps interactivos del dashboard. */
+:host.tm-static ::ng-deep ngx-charts-tree-map,
+:host.tm-static ::ng-deep ngx-charts-tree-map * {
+  cursor: default !important;
+}

--- a/src/app/shared/components/visuals/tree-map-chart/tree-map-chart.component.ts
+++ b/src/app/shared/components/visuals/tree-map-chart/tree-map-chart.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
+import {Component, EventEmitter, HostBinding, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
 import {NameValue} from "../../../interfaces/dashboard.interface";
 import {Color, ScaleType} from "@swimlane/ngx-charts";
 import {VisualsService} from "../../../domain/services/visuals.service";
@@ -17,6 +17,11 @@ export class TreeMapChartComponent implements OnInit, OnChanges {
   @Input()
   height!: number;
   @Output() selectedTopic = new EventEmitter<any>();
+
+  // Cuando es false, los recuadros no actuan (no hay accion al clic) y se muestra el
+  // cursor por defecto en vez del de mano (p. ej. en el fingerprint del perfil).
+  @Input() clickable: boolean = true;
+  @HostBinding('class.tm-static') get tmStatic(): boolean { return !this.clickable; }
 
   gradient: boolean = false;
   animations: boolean = true;


### PR DESCRIPTION
## Resumen
Mejoras de la **pantalla de detalle de autor** del buscador y arreglos del **header** compartido. El cambio principal es la **vista pública del perfil de autor**: un usuario sin sesión puede ver el detalle académico de un autor. Incluye además loaders/estados vacíos, paginación, rediseño del grafo de coautores y correcciones de UI.

## Cambios

### Detalle de autor (módulo `profile/`)
- **Vista pública:** sin sesión, el detalle de un autor se muestra en `/profile/{scopus_id}` sin redirigir a login. Cuando el id es un `scopus_id` numérico se carga el detalle público directamente, evitando la llamada autenticada que devolvía `401 → login`. Las pestañas (network/article/fingerprint) ya resolvían al autor por `scopus_id` contra la API pública del microservicio v2.
- **Loaders + estados vacíos** en Network, Articles y Fingerprint: spinner en la primera carga y mensaje cuando el autor no tiene coautores / artículos / áreas temáticas. Corrige que **Fingerprint quedaba en blanco** cuando el autor tenía ≤1 tema.
- **Paginación en cliente** del tab Articles.
- Recuadros del **Fingerprint no clicables** (cursor por defecto en vez de mano).
- Fix de **parpadeo y espacio en blanco** al cambiar de pestaña (desplazamiento suave a la barra de pestañas).

### Grafo de coautores (Network)
- Adopta el diseño del grafo de *Relevant Authors*: chips de **Nodos/Relaciones**, botón **"Descargar todo"** (PNG) y **controles de zoom** (+ / − / centrar).

### Header (compartido)
- **Tabs Home/Analytics/About visibles en modo oscuro del SO:** se eliminó un bloque `@media (prefers-color-scheme: dark)` que dejaba el texto casi-blanco sobre la barra blanca (las tabs solo se veían al hacer hover o estando activas).
- **Analytics/About con navegación absoluta** (`/home/analitica`, `/home/about-us/getting-started`): antes, desde `/profile/:id`, los enlaces relativos rompían y redirigían a Home.
- **Flecha del menú de usuario** centrada y rotando sobre su propio eje.

## Pruebas
- **Suite B (E2E Selenium): 16/16 PASS**, incluidos 3 casos nuevos sobre el detalle de autor:
  - E-14: grafo de coautores → "Descargar todo" genera PNG.
  - E-15: paginación del tab Articles (autor con 70 artículos → página 2 distinta).
  - E-16: Fingerprint muestra el tree map de temas o el mensaje de vacío (nunca en blanco).

## Cómo probar
1. Sin iniciar sesión, abrir un autor desde el buscador → debe mostrarse el perfil (no redirige a login).
2. Recorrer Network / Articles / Fingerprint: loaders en la primera carga y mensajes cuando no hay datos.
3. En Network: probar "Descargar todo" y el zoom.
4. Verificar Home/Analytics/About visibles con Windows en modo oscuro y que naveguen desde la pantalla de autor.

Generated with [Claude Code](https://claude.com/claude-code)