### PR TITLE
Mejoras de usabilidad en el grafo de autores relevantes (filtro de afiliaciones, paneo y botón "Ver todo")

### DIFF
--- a/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.html
+++ b/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.html
@@ -91,7 +91,7 @@
         <div class="absolute top-4 right-4 z-30 flex flex-col gap-2">
           <button (click)="zoomIn()" class="bg-white border shadow-md w-10 h-10 rounded-full flex items-center justify-center hover:bg-gray-100 text-2xl font-bold text-gray-700 select-none">+</button>
           <button (click)="zoomOut()" class="bg-white border shadow-md w-10 h-10 rounded-full flex items-center justify-center hover:bg-gray-100 text-2xl font-bold text-gray-700 select-none">-</button>
-          <button (click)="resetZoom()" class="bg-white border shadow-md w-10 h-10 rounded-full flex items-center justify-center hover:bg-gray-100 text-gray-700 mt-2" title="Center">
+          <button (click)="fitAll()" class="bg-white border shadow-md w-10 h-10 rounded-full flex items-center justify-center hover:bg-gray-100 text-gray-700 mt-2" title="Ver todo">
             <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor"><path d="M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Zm40 360q-134 0-227-93T160-400q0-134 93-227t227-93q134 0 227 93t93 227q0 134-93 227t-227 93Zm0-80q100 0 170-70t70-170q0-100-70-170t-170-70q-100 0-170 70t-70 170q0 100 70 170t170 70Zm0-240Z"/></svg>
           </button>
         </div>

--- a/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.html
+++ b/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.html
@@ -21,8 +21,21 @@
     <div class="py-2 px-4 font-semibold border-b border-gray-200 text-gray-700 bg-gray-50 text-sm tracking-wide" *ngIf="affiliations && affiliations.length > 0">
       Affiliations
     </div>
+    <!-- Buscador de afiliaciones (mejora de usabilidad: evita scroll en lista larga) -->
+    <div class="py-2 px-4 border-b border-gray-200 bg-white" *ngIf="affiliations && affiliations.length > 0">
+      <div class="flex items-center gap-2 border border-gray-300 rounded-md px-3 py-1.5 focus-within:border-red-500">
+        <fa-icon [icon]="faMagnifyingGlass" class="text-red-600 text-sm"></fa-icon>
+        <input
+          type="text"
+          [(ngModel)]="affiliationSearch"
+          placeholder="Search affiliations..."
+          class="text-sm"
+          style="flex:1; background:transparent; border:none; outline:none;"
+        >
+      </div>
+    </div>
     <div class="py-3 px-4 flex md:flex-col gap-3 max-h-96 overflow-y-auto bg-white" *ngIf="affiliations && affiliations.length > 0">
-      <div class="flex gap-3 items-center hover:bg-gray-50 p-1 rounded transition-colors" *ngFor="let aff of affiliations">
+      <div class="flex gap-3 items-center hover:bg-gray-50 p-1 rounded transition-colors" *ngFor="let aff of filteredAffiliations">
         <input
           [id]="aff.scopus_id"
           type="checkbox"
@@ -32,6 +45,7 @@
         >
         <label [for]="aff.scopus_id" class="ml-2 text-sm text-gray-600 cursor-pointer flex-1 leading-tight">{{aff.name}}</label>
       </div>
+      <div *ngIf="filteredAffiliations.length === 0" class="text-sm text-gray-400 italic p-1">Sin coincidencias</div>
     </div>
   </app-filters-sidebar>
 

--- a/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.ts
+++ b/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.ts
@@ -1,7 +1,7 @@
 import {Component, ElementRef, EventEmitter, Inject, Input, Output, SimpleChanges, ViewChild} from "@angular/core";
 import {Link, Node} from "../../../../../shared/d3";
 import {AuthorNode, Coauthors} from "../../../../../shared/interfaces/author.interface";
-import {faDownload, faVectorSquare} from "@fortawesome/free-solid-svg-icons";
+import {faDownload, faVectorSquare, faMagnifyingGlass} from "@fortawesome/free-solid-svg-icons";
 import {DOCUMENT} from "@angular/common";
 import {AuthorService} from "../../../../domain/services/author.service";
 import {catchError, EMPTY, of, tap} from "rxjs";
@@ -30,6 +30,7 @@ export class MostRelevantAuthorsGraphComponent {
   authorsNumber: number = 50
   affiliations!: { scopus_id: string, name: string }[]
   selectedAffiliations: string[] = []
+  affiliationSearch: string = ''
   noResults = false;
   isLoadingResults = false;
   isFirstLoad = true;
@@ -38,6 +39,7 @@ export class MostRelevantAuthorsGraphComponent {
   @ViewChild("downloadEl") downloadEl!: ElementRef;
   faDownload = faDownload
   faVectorSquare = faVectorSquare
+  faMagnifyingGlass = faMagnifyingGlass
 
   // Seleccion de zona para exportar solo una parte del grafo
   selectingRegion = false
@@ -57,6 +59,7 @@ export class MostRelevantAuthorsGraphComponent {
       this.isFirstLoad = true;
       this.noResults = false;
       this.selectedAffiliations = [];
+      this.affiliationSearch = '';
       if (this.authorsNumber === 0) {
         this.authorsNumber = 50;
       }
@@ -84,6 +87,7 @@ export class MostRelevantAuthorsGraphComponent {
           this.affiliations = []
           coauthors.nodes.length === 0 ? this.noResults = true : this.noResults = false;
           this.affiliations = coauthors.affiliations;
+          this.sortAffiliations();
           this.setupGraph(coauthors);
           this.showGraph = true;
           this.isFirstLoad = false;
@@ -142,9 +146,22 @@ export class MostRelevantAuthorsGraphComponent {
         const bSelected = this.selectedAffiliations.includes(b.scopus_id);
         if (aSelected && !bSelected) return -1;
         if (!aSelected && bSelected) return 1;
-        return 0;
+        return this.normalize(a.name).localeCompare(this.normalize(b.name));
       });
     }
+  }
+
+  /** Normaliza texto para buscar/ordenar sin importar mayusculas ni acentos. */
+  private normalize(text: string): string {
+    return (text || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().trim();
+  }
+
+  /** Afiliaciones visibles segun el texto del buscador (coincidencia parcial, sin acentos/mayusculas). */
+  get filteredAffiliations(): { scopus_id: string, name: string }[] {
+    if (!this.affiliations) return [];
+    const term = this.normalize(this.affiliationSearch);
+    if (!term) return this.affiliations;
+    return this.affiliations.filter(aff => this.normalize(aff.name).includes(term));
   }
 
   onClickAffiliationsFilter(type: string) {
@@ -195,6 +212,7 @@ export class MostRelevantAuthorsGraphComponent {
             coauthors.nodes.length === 0 ? this.noResults = true : this.noResults = false;
             // console.log('dentro2: xd'+ this.authorsNumber)
             this.affiliations = coauthors.affiliations;
+            this.sortAffiliations();
             this.setupGraph(coauthors);
             this.showGraph = true;
             this.isFirstLoad = false;

--- a/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.ts
+++ b/src/app/search-engine/presentation/home-page/components/most-relevant-authors-graph/most-relevant-authors-graph.component.ts
@@ -400,4 +400,10 @@ export class MostRelevantAuthorsGraphComponent {
       data.svg.transition().duration(750).call(data.zoom.transform, d3.zoomIdentity.translate(width / 2, height / 2).scale(0.3).translate(-width / 2, -height / 2));
     }
   }
+
+  /** Ajusta zoom y paneo para que TODO el grafo entre en la vista, igual que la
+   *  descarga. Usado por el boton "Ver todo" (antes "Centrar", que solo escalaba a 0.3). */
+  fitAll(): void {
+    this.fitGraphToView(600);
+  }
 }

--- a/src/app/shared/components/visuals/graph/graph.component.css
+++ b/src/app/shared/components/visuals/graph/graph.component.css
@@ -1,0 +1,15 @@
+/* El host y el svg llenan el contenedor padre (ej. el div h-[800px] del grafo de
+   autores relevantes). Asi el area interactiva del d3.zoom cubre TODO el contenedor
+   y el arrastre para mover/paneo funciona en cualquier parte, no solo donde llegaba
+   el svg (que antes quedaba mas corto que el contenedor y dejaba zona muerta). */
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
## Contexto
Mejoras de interacción sobre el grafo de autores relevantes, detectadas durante las
pruebas de usabilidad. Son cambios de interfaz, sin tocar el backend ni el contrato de la API.

## Cambios
- **Filtro de afiliaciones con buscador.** La lista de afiliaciones podía tener 200
  casillas y obligaba a hacer scroll. Se añade un campo de búsqueda que filtra en vivo
  (insensible a mayúsculas y tildes) y las afiliaciones se ordenan alfabéticamente
  (las seleccionadas primero). El campo se limpia al cambiar de consulta.
  Incluye ícono de lupa (rojo) y placeholder en inglés, consistente con la interfaz.
- **Paneo en toda el área del grafo.** El `<svg>` quedaba más corto que su contenedor,
  así que arrastrar en la zona en blanco solo seleccionaba texto en lugar de mover el grafo.
  Ahora el host y el svg llenan el contenedor, de modo que el área de arrastre (d3.zoom)
  cubre todo el espacio.
- **Botón "Ver todo" (antes "Centrar").** Antes solo aplicaba una escala fija (0.3).
  Ahora ajusta zoom y paneo para que todos los nodos entren en la vista, con el mismo
  comportamiento que "Descargar todo".

## Archivos
- `most-relevant-authors-graph.component.ts`
- `most-relevant-authors-graph.component.html`
- `shared/components/visuals/graph/graph.component.css`

## Pruebas
Verificado con la suite E2E (Selenium) de la interfaz. Sin cambios de backend.