### PR TITLE
feat: dashboard de equidad (fairness) del buscador en /admin

### DIFF
--- a/src/app/search-engine/domain/entities/fairness.interface.ts
+++ b/src/app/search-engine/domain/entities/fairness.interface.ts
@@ -1,0 +1,83 @@
+// Modelo de datos del dashboard de fairness (mitigacion de sesgos).
+// Refleja el JSON que sirve /v1/dashboard/fairness/summary/ (resultados S5-S10).
+
+export interface FairnessThresholds {
+  di_min: number;
+  spd: number[];          // [-0.1, 0.1]
+  util_max_drop: number;  // 0.05
+}
+
+export interface FairnessMeta {
+  generated: string;
+  proyecto: string;
+  thresholds: FairnessThresholds;
+}
+
+export interface ShapItem {
+  feature: string;
+  pct: number;
+}
+
+export interface AlphaPoint {
+  alpha: number;
+  SPD: number;
+  DI: number;
+  accuracy: number;
+  caida_util: number;
+  tasa_pequena: number;
+  spd_ok: boolean;
+  di_ok: boolean;
+}
+
+export interface LambdaPoint {
+  lambda: number;
+  n_areas: number;
+  gini: number;
+  ndcg: number;
+  score: number;
+  caida_ndcg: number;
+}
+
+export interface ModelMitigation {
+  baseline: { [k: string]: number };
+  reweighing: { [k: string]: number };
+  threshold_adj: { [k: string]: number };
+  alpha_optimo: number;
+  alpha_sweep: AlphaPoint[];
+}
+
+export interface SearchMitigation {
+  lambda_optimo: number;
+  lambda_sweep: LambdaPoint[];
+  comparison: Array<{ [k: string]: number | string }>;
+}
+
+export interface SelectionItem {
+  estrategia: string;
+  parametro: string;
+  cumple_equidad: boolean;
+  cumple_utilidad: boolean;
+  equidad: string;
+  utilidad: string;
+  robustez: string;
+  decision: string;
+  alternativa: string;
+  efecto_servicio?: string;
+}
+
+export interface FairnessSelection {
+  modelo_predictivo: SelectionItem;
+  motor_busqueda: SelectionItem;
+  umbrales: FairnessThresholds;
+}
+
+export interface FairnessSummary {
+  meta: FairnessMeta;
+  baseline: Array<{ [k: string]: number | string }>;
+  shap: ShapItem[];
+  model_mitigation: ModelMitigation;
+  search_mitigation: SearchMitigation;
+  impact: Array<{ [k: string]: number | string }>;
+  verdict: Array<{ [k: string]: number | string }>;
+  selection: FairnessSelection;
+}

--- a/src/app/search-engine/domain/services/fairness.service.ts
+++ b/src/app/search-engine/domain/services/fairness.service.ts
@@ -1,0 +1,48 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import {
+  FairnessSummary,
+} from '../entities/fairness.interface';
+
+/**
+ * Consume los endpoints del dashboard de fairness (modulo admin).
+ * Sirven los resultados pre-calculados de la mitigacion de sesgos (S5-S10).
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class FairnessService {
+  private rootURL: string = environment.apiCentinela;
+
+  constructor(private httpClient: HttpClient) {}
+
+  /** Todos los resultados consolidados en una sola llamada. */
+  getSummary(): Observable<FairnessSummary> {
+    return this.httpClient.get<FairnessSummary>(
+      `${this.rootURL}/v1/dashboard/fairness/summary/`
+    );
+  }
+
+  /** Linea base de equidad (diagnostico S5) + importancia SHAP. */
+  getBaseline(): Observable<Partial<FairnessSummary>> {
+    return this.httpClient.get<Partial<FairnessSummary>>(
+      `${this.rootURL}/v1/dashboard/fairness/baseline/`
+    );
+  }
+
+  /** Impacto antes/despues, veredicto contra umbrales y seleccion final (S10). */
+  getMitigation(): Observable<Partial<FairnessSummary>> {
+    return this.httpClient.get<Partial<FairnessSummary>>(
+      `${this.rootURL}/v1/dashboard/fairness/mitigation/`
+    );
+  }
+
+  /** Barridos de sensibilidad de alpha (modelo) y lambda (buscador). */
+  getSensitivity(): Observable<Partial<FairnessSummary>> {
+    return this.httpClient.get<Partial<FairnessSummary>>(
+      `${this.rootURL}/v1/dashboard/fairness/sensitivity/`
+    );
+  }
+}

--- a/src/app/search-engine/presentation/admin/admin-rounting.module.ts
+++ b/src/app/search-engine/presentation/admin/admin-rounting.module.ts
@@ -6,6 +6,7 @@ import {  UpdateCentinelaComponent } from "./components/update-centinela/update-
 import { MainContentComponent } from "./components/main-content/main-content.component";
 import { loginGuard } from "src/guards/login.guard";
 import { LoggerComponent } from "./components/logger/logger.component";
+import { FairnessDashboardComponent } from "./pages/fairness-dashboard/fairness-dashboard.component";
 
 const routes: Routes = [
   {
@@ -28,6 +29,10 @@ const routes: Routes = [
       {
         path:'logger',
         component:LoggerComponent
+      },
+      {
+        path:'fairness',
+        component:FairnessDashboardComponent
       },
       {
         path:'',

--- a/src/app/search-engine/presentation/admin/admin.module.ts
+++ b/src/app/search-engine/presentation/admin/admin.module.ts
@@ -18,6 +18,8 @@ import { MainContentComponent } from './components/main-content/main-content.com
 import { UpdateCentinelaComponent } from './components/update-centinela/update-centinela.component';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import { LoggerComponent } from './components/logger/logger.component';
+import { FairnessDashboardComponent } from './pages/fairness-dashboard/fairness-dashboard.component';
+import { NgxChartsModule } from '@swimlane/ngx-charts';
 
 @NgModule({
   imports: [
@@ -33,7 +35,8 @@ import { LoggerComponent } from './components/logger/logger.component';
     AdminRoutingModule,
     CommonModule,
     MatProgressSpinnerModule,
-    FormsModule
+    FormsModule,
+    NgxChartsModule
   ],
   exports: [],
   declarations: [
@@ -44,7 +47,8 @@ import { LoggerComponent } from './components/logger/logger.component';
     SidebarDashboardComponent,
     MainContentComponent,
     UpdateCentinelaComponent,
-    LoggerComponent
+    LoggerComponent,
+    FairnessDashboardComponent
   ],
   providers: [],
 })

--- a/src/app/search-engine/presentation/admin/components/sidebar/sidebar.component.html
+++ b/src/app/search-engine/presentation/admin/components/sidebar/sidebar.component.html
@@ -32,6 +32,16 @@
           </button>
         </a>
       </li>
+      <li>
+        <a routerLink="fairness" >
+          <button routerLinkActive="active" class="middle none font-sans font-bold center transition-all disabled:opacity-50 disabled:shadow-none disabled:pointer-events-none text-xs py-3 rounded-lg text-white hover:bg-white/10 active:bg-white/30 w-full flex items-center gap-4 px-4 capitalize" type="button">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" class="w-5 h-5 text-inherit">
+              <path fill-rule="evenodd" d="M12 2.25c.414 0 .75.336.75.75v.518a8.252 8.252 0 016.482 6.482h.518a.75.75 0 010 1.5h-.518a8.252 8.252 0 01-6.482 6.482v.518a.75.75 0 01-1.5 0v-.518a8.252 8.252 0 01-6.482-6.482H3.75a.75.75 0 010-1.5h.518A8.252 8.252 0 0110.5 3.518V3c0-.414.336-.75.75-.75zm-.75 3.026a6.75 6.75 0 00-4.974 4.974H8.25a.75.75 0 010 1.5H6.276a6.75 6.75 0 004.974 4.974V15a.75.75 0 011.5 0v1.724a6.75 6.75 0 004.974-4.974H15.75a.75.75 0 010-1.5h1.974A6.75 6.75 0 0012.75 5.276V7a.75.75 0 01-1.5 0V5.276z" clip-rule="evenodd"></path>
+            </svg>
+            <p class="block antialiased font-sans text-base leading-relaxed text-inherit font-medium capitalize">Equidad</p>
+          </button>
+        </a>
+      </li>
     </ul>
     <ul class="mb-4 flex flex-col gap-1">
       <li class="mx-3.5 mt-4 mb-2">

--- a/src/app/search-engine/presentation/admin/pages/fairness-dashboard/fairness-dashboard.component.css
+++ b/src/app/search-engine/presentation/admin/pages/fairness-dashboard/fairness-dashboard.component.css
@@ -1,0 +1,8 @@
+:host {
+  display: block;
+}
+
+table th {
+  font-weight: 600;
+  white-space: nowrap;
+}

--- a/src/app/search-engine/presentation/admin/pages/fairness-dashboard/fairness-dashboard.component.html
+++ b/src/app/search-engine/presentation/admin/pages/fairness-dashboard/fairness-dashboard.component.html
@@ -1,0 +1,336 @@
+<div class="px-2">
+  <h1 class="text-2xl font-bold text-gray-800">Dashboard de equidad (fairness)</h1>
+  <p class="text-sm text-gray-500 mb-6">
+    Resultados consolidados de la mitigacion de sesgos del Proyecto Centinela.
+  </p>
+
+  <!-- Estado de carga / error -->
+  <div *ngIf="loading" class="flex items-center gap-3 text-gray-500 py-10">
+    <mat-progress-spinner mode="indeterminate" diameter="28"></mat-progress-spinner>
+    <span>Cargando resultados de equidad...</span>
+  </div>
+  <div *ngIf="error" class="bg-red-50 border border-red-200 text-red-700 rounded-lg p-4">
+    {{ error }}
+  </div>
+
+  <ng-container *ngIf="data && !loading">
+    <!-- Umbrales de aceptacion -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+      <div class="bg-white rounded-xl shadow p-4 border-l-4 border-blue-500">
+        <p class="text-xs uppercase text-gray-400">Impacto desigual (DI)</p>
+        <p class="text-xl font-bold text-gray-800">&ge; {{ data.meta.thresholds.di_min }}</p>
+        <p class="text-xs text-gray-400">regla de los 4/5</p>
+      </div>
+      <div class="bg-white rounded-xl shadow p-4 border-l-4 border-blue-500">
+        <p class="text-xs uppercase text-gray-400">Paridad estadistica (SPD)</p>
+        <p class="text-xl font-bold text-gray-800">
+          [{{ data.meta.thresholds.spd[0] }}, {{ data.meta.thresholds.spd[1] }}]
+        </p>
+        <p class="text-xs text-gray-400">banda aceptable</p>
+      </div>
+      <div class="bg-white rounded-xl shadow p-4 border-l-4 border-blue-500">
+        <p class="text-xs uppercase text-gray-400">Degradacion de utilidad</p>
+        <p class="text-xl font-bold text-gray-800">&le; {{ data.meta.thresholds.util_max_drop * 100 }}%</p>
+        <p class="text-xs text-gray-400">respecto a la linea base</p>
+      </div>
+    </div>
+
+    <!-- SHAP: origen del sesgo institucional -->
+    <section class="bg-white rounded-xl shadow p-5 mb-8">
+      <h2 class="text-lg font-semibold text-gray-800 mb-1">Origen del sesgo: importancia de variables (SHAP)</h2>
+      <p class="text-sm text-gray-500 mb-3">
+        El sesgo institucional es indirecto: lo domina <b>publication_count</b>, no la afiliacion.
+      </p>
+      <ngx-charts-bar-horizontal
+        [view]="[760, 260]"
+        [results]="shapData"
+        [scheme]="schemeMetric"
+        [xAxis]="true"
+        [yAxis]="true"
+        [showXAxisLabel]="true"
+        [showYAxisLabel]="false"
+        xAxisLabel="% de importancia"
+        [showDataLabel]="true"
+        [roundDomains]="true">
+      </ngx-charts-bar-horizontal>
+    </section>
+
+    <!-- Linea base (S5) -->
+    <section class="bg-white rounded-xl shadow p-5 mb-8">
+      <h2 class="text-lg font-semibold text-gray-800 mb-3">Linea base de equidad (diagnostico inicial)</h2>
+      <div class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead>
+            <tr class="text-left text-gray-500 border-b">
+              <th class="py-2 pr-4">Atributo</th>
+              <th class="py-2 pr-4">Metrica</th>
+              <th class="py-2 pr-4">Valor</th>
+              <th class="py-2 pr-4">Umbral</th>
+              <th class="py-2 pr-4">Estado</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let r of data.baseline" class="border-b last:border-0">
+              <td class="py-2 pr-4">{{ r['Atributo'] }}</td>
+              <td class="py-2 pr-4">{{ r['Metrica'] }}</td>
+              <td class="py-2 pr-4">{{ r['Valor'] }}</td>
+              <td class="py-2 pr-4 text-gray-500">{{ r['Umbral'] }}</td>
+              <td class="py-2 pr-4" [ngClass]="estadoClass(r['Estado'] + '')">{{ r['Estado'] }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Antes/despues -->
+    <section class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+      <div class="bg-white rounded-xl shadow p-5">
+        <h3 class="font-semibold text-gray-800 mb-1">Modelo predictivo: DI antes/despues</h3>
+        <p class="text-xs text-gray-400 mb-2">Ajuste de umbrales (alpha={{ data.model_mitigation.alpha_optimo }})</p>
+        <ngx-charts-bar-vertical
+          [view]="[360, 240]"
+          [results]="antesDespuesModelo"
+          [scheme]="schemeBeforeAfter"
+          [xAxis]="true"
+          [yAxis]="true"
+          [showDataLabel]="true"
+          [roundDomains]="true">
+        </ngx-charts-bar-vertical>
+      </div>
+      <div class="bg-white rounded-xl shadow p-5">
+        <h3 class="font-semibold text-gray-800 mb-1">Motor de busqueda: diversidad antes/despues</h3>
+        <p class="text-xs text-gray-400 mb-2">xQUAD (lambda={{ data.search_mitigation.lambda_optimo }}); # areas en top-50</p>
+        <ngx-charts-bar-vertical
+          [view]="[360, 240]"
+          [results]="antesDespuesBuscador"
+          [scheme]="schemeBeforeAfter"
+          [xAxis]="true"
+          [yAxis]="true"
+          [showDataLabel]="true"
+          [roundDomains]="true">
+        </ngx-charts-bar-vertical>
+      </div>
+    </section>
+
+    <!-- Sensibilidad alpha (modelo predictivo) -->
+    <section class="bg-white rounded-xl shadow p-5 mb-8">
+      <h2 class="text-lg font-semibold text-gray-800 mb-1">Sensibilidad del modelo al parametro &alpha;</h2>
+      <p class="text-sm text-gray-500 mb-4">
+        Mueva el control para recorrer el compromiso equidad-utilidad y ver el punto de operacion.
+      </p>
+
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <div class="lg:col-span-2">
+          <ngx-charts-line-chart
+            [view]="[520, 280]"
+            [results]="alphaDiSpd"
+            [scheme]="schemeMetric"
+            [xAxis]="true"
+            [yAxis]="true"
+            [showXAxisLabel]="true"
+            [showYAxisLabel]="true"
+            xAxisLabel="alpha"
+            yAxisLabel="DI / SPD"
+            [legend]="true"
+            legendTitle="Metrica"
+            [referenceLines]="diRef"
+            [showRefLines]="true"
+            [showRefLabels]="true"
+            [roundDomains]="true">
+          </ngx-charts-line-chart>
+          <ngx-charts-line-chart
+            class="block mt-2"
+            [view]="[520, 200]"
+            [results]="alphaUtil"
+            [scheme]="schemeUtil"
+            [xAxis]="true"
+            [yAxis]="true"
+            [showXAxisLabel]="true"
+            [showYAxisLabel]="true"
+            xAxisLabel="alpha"
+            yAxisLabel="caida util (%)"
+            [referenceLines]="utilRef5"
+            [showRefLines]="true"
+            [showRefLabels]="true"
+            [roundDomains]="true">
+          </ngx-charts-line-chart>
+        </div>
+
+        <!-- Panel del punto seleccionado (control interactivo) -->
+        <div class="bg-gray-50 rounded-lg p-4 border">
+          <label class="text-sm font-medium text-gray-700">
+            alpha = <span class="text-indigo-600 font-bold">{{ alphaPoint?.alpha | number: '1.1-1' }}</span>
+          </label>
+          <input type="range" min="0" max="10" step="1" [(ngModel)]="alphaIdx" class="w-full mt-2" />
+
+          <div class="mt-3 space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-gray-500">DI</span>
+              <span class="font-semibold">{{ alphaPoint?.DI | number: '1.3-3' }}</span>
+              <span [ngClass]="alphaPoint?.di_ok ? 'text-green-600' : 'text-red-600'">
+                {{ alphaPoint?.di_ok ? 'CUMPLE' : 'NO' }}
+              </span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-gray-500">SPD</span>
+              <span class="font-semibold">{{ alphaPoint?.SPD | number: '1.3-3' }}</span>
+              <span [ngClass]="alphaPoint?.spd_ok ? 'text-green-600' : 'text-red-600'">
+                {{ alphaPoint?.spd_ok ? 'CUMPLE' : 'NO' }}
+              </span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-gray-500">Caida util.</span>
+              <span class="font-semibold">{{ alphaPoint?.caida_util | number: '1.1-1' }}%</span>
+              <span [ngClass]="alphaUtilOk ? 'text-green-600' : 'text-red-600'">
+                {{ alphaUtilOk ? 'CUMPLE' : 'NO' }}
+              </span>
+            </div>
+            <div class="flex justify-between border-t pt-2">
+              <span class="text-gray-500">Tasa inst. pequenas</span>
+              <span class="font-semibold">{{ alphaPoint?.tasa_pequena | number: '1.1-1' }}%</span>
+              <span></span>
+            </div>
+          </div>
+          <p class="text-xs text-gray-400 mt-3">
+            Ventana de equidad: alpha &isin; [0,3 ; 0,6]. Ningun alpha cumple equidad y utilidad a la vez.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Sensibilidad lambda (motor de busqueda) -->
+    <section class="bg-white rounded-xl shadow p-5 mb-8">
+      <h2 class="text-lg font-semibold text-gray-800 mb-1">Sensibilidad del buscador al parametro &lambda;</h2>
+      <p class="text-sm text-gray-500 mb-4">
+        Compromiso entre diversidad tematica y relevancia (NDCG).
+      </p>
+
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <div class="lg:col-span-2">
+          <ngx-charts-line-chart
+            [view]="[520, 240]"
+            [results]="lambdaAreas"
+            [scheme]="schemeAreas"
+            [xAxis]="true"
+            [yAxis]="true"
+            [showXAxisLabel]="true"
+            [showYAxisLabel]="true"
+            xAxisLabel="lambda"
+            yAxisLabel="# areas"
+            [roundDomains]="true">
+          </ngx-charts-line-chart>
+          <ngx-charts-line-chart
+            class="block mt-2"
+            [view]="[520, 200]"
+            [results]="lambdaNdcg"
+            [scheme]="schemeUtil"
+            [xAxis]="true"
+            [yAxis]="true"
+            [showXAxisLabel]="true"
+            [showYAxisLabel]="true"
+            xAxisLabel="lambda"
+            yAxisLabel="caida NDCG (%)"
+            [referenceLines]="utilRef5"
+            [showRefLines]="true"
+            [showRefLabels]="true"
+            [roundDomains]="true">
+          </ngx-charts-line-chart>
+        </div>
+
+        <div class="bg-gray-50 rounded-lg p-4 border">
+          <label class="text-sm font-medium text-gray-700">
+            lambda = <span class="text-indigo-600 font-bold">{{ lambdaPoint?.lambda | number: '1.1-1' }}</span>
+          </label>
+          <input type="range" min="0" max="10" step="1" [(ngModel)]="lambdaIdx" class="w-full mt-2" />
+
+          <div class="mt-3 space-y-2 text-sm">
+            <div class="flex justify-between">
+              <span class="text-gray-500"># areas</span>
+              <span class="font-semibold">{{ lambdaPoint?.n_areas | number: '1.1-1' }}</span>
+              <span></span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-gray-500">NDCG</span>
+              <span class="font-semibold">{{ lambdaPoint?.ndcg | number: '1.3-3' }}</span>
+              <span></span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-gray-500">Caida NDCG</span>
+              <span class="font-semibold">{{ lambdaPoint?.caida_ndcg | number: '1.1-1' }}%</span>
+              <span [ngClass]="lambdaUtilOk ? 'text-green-600' : 'text-red-600'">
+                {{ lambdaUtilOk ? 'CUMPLE' : 'NO' }}
+              </span>
+            </div>
+            <div class="flex justify-between border-t pt-2">
+              <span class="text-gray-500">Gini areas</span>
+              <span class="font-semibold">{{ lambdaPoint?.gini | number: '1.3-3' }}</span>
+              <span></span>
+            </div>
+          </div>
+          <p class="text-xs text-gray-400 mt-3">
+            lambda=0,7 maximiza diversidad (al limite del 5%); lambda=0,6 es el punto conservador.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- xQUAD por consulta -->
+    <section class="bg-white rounded-xl shadow p-5 mb-8">
+      <h2 class="text-lg font-semibold text-gray-800 mb-1">Diversidad por consulta: BM25 vs xQUAD</h2>
+      <p class="text-sm text-gray-500 mb-3"># de areas unicas en el top-50 (mayor es mas diverso).</p>
+      <ngx-charts-bar-vertical-2d
+        [view]="[760, 300]"
+        [results]="queryData"
+        [scheme]="schemeQuery"
+        [xAxis]="true"
+        [yAxis]="true"
+        [legend]="true"
+        legendTitle="Metodo"
+        [showDataLabel]="true"
+        [roundDomains]="true">
+      </ngx-charts-bar-vertical-2d>
+    </section>
+
+    <!-- Veredicto contra umbrales (H2 - S10) -->
+    <section class="bg-white rounded-xl shadow p-5 mb-8">
+      <h2 class="text-lg font-semibold text-gray-800 mb-3">Veredicto frente a los umbrales de aceptacion</h2>
+      <div class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead>
+            <tr class="text-left text-gray-500 border-b">
+              <th *ngFor="let c of verdictCols" class="py-2 pr-4">{{ c }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let r of data.verdict" class="border-b last:border-0">
+              <td *ngFor="let c of verdictCols" class="py-2 pr-4"
+                  [ngClass]="c === 'Veredicto' ? estadoClass(r[c] + '') : 'text-gray-700'">
+                {{ r[c] }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Seleccion fundamentada -->
+    <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="bg-white rounded-xl shadow p-5 border-t-4 border-indigo-500">
+        <h3 class="font-semibold text-gray-800">Modelo predictivo</h3>
+        <p class="text-sm text-indigo-600 font-medium mb-2">{{ data.selection.modelo_predictivo.parametro }}</p>
+        <p class="text-sm text-gray-600"><b>Equidad:</b> {{ data.selection.modelo_predictivo.equidad }}</p>
+        <p class="text-sm text-gray-600"><b>Utilidad:</b> {{ data.selection.modelo_predictivo.utilidad }}</p>
+        <p class="text-sm text-gray-600"><b>Decision:</b> {{ data.selection.modelo_predictivo.decision }}</p>
+      </div>
+      <div class="bg-white rounded-xl shadow p-5 border-t-4 border-indigo-500">
+        <h3 class="font-semibold text-gray-800">Motor de busqueda</h3>
+        <p class="text-sm text-indigo-600 font-medium mb-2">{{ data.selection.motor_busqueda.parametro }}</p>
+        <p class="text-sm text-gray-600"><b>Equidad:</b> {{ data.selection.motor_busqueda.equidad }}</p>
+        <p class="text-sm text-gray-600"><b>Utilidad:</b> {{ data.selection.motor_busqueda.utilidad }}</p>
+        <p class="text-sm text-gray-600"><b>Decision:</b> {{ data.selection.motor_busqueda.decision }}</p>
+      </div>
+    </section>
+
+    <p class="text-xs text-gray-400 mt-6">Datos generados: {{ data.meta.generated }}.</p>
+  </ng-container>
+</div>

--- a/src/app/search-engine/presentation/admin/pages/fairness-dashboard/fairness-dashboard.component.ts
+++ b/src/app/search-engine/presentation/admin/pages/fairness-dashboard/fairness-dashboard.component.ts
@@ -1,0 +1,210 @@
+import { Component, OnInit } from '@angular/core';
+import { Color, ScaleType } from '@swimlane/ngx-charts';
+import { FairnessService } from 'src/app/search-engine/domain/services/fairness.service';
+import {
+  FairnessSummary,
+  AlphaPoint,
+  LambdaPoint,
+} from 'src/app/search-engine/domain/entities/fairness.interface';
+
+@Component({
+  selector: 'app-fairness-dashboard',
+  templateUrl: './fairness-dashboard.component.html',
+  styleUrls: ['./fairness-dashboard.component.css'],
+})
+export class FairnessDashboardComponent implements OnInit {
+  data?: FairnessSummary;
+  loading = true;
+  error = '';
+
+  verdictCols = ['Componente', 'Estrategia', 'DI', 'SPD', 'Caida util', 'Veredicto'];
+
+  // ---- Datos para los graficos (ngx-charts) ----
+  shapData: { name: string; value: number }[] = [];
+  alphaDiSpd: { name: string; series: { name: string; value: number }[] }[] = [];
+  alphaUtil: { name: string; series: { name: string; value: number }[] }[] = [];
+  lambdaAreas: { name: string; series: { name: string; value: number }[] }[] = [];
+  lambdaNdcg: { name: string; series: { name: string; value: number }[] }[] = [];
+  antesDespuesModelo: { name: string; value: number }[] = [];
+  antesDespuesBuscador: { name: string; value: number }[] = [];
+  queryData: { name: string; series: { name: string; value: number }[] }[] = [];
+
+  // ---- Controles interactivos ----
+  alphaIdx = 3; // alpha = 0.3 por defecto
+  lambdaIdx = 7; // lambda = 0.7 por defecto
+
+  // ---- Lineas de referencia (umbrales) ----
+  diRef = [{ name: 'DI min 0,8', value: 0.8 }];
+  utilRef5 = [{ name: 'Umbral 5%', value: 5 }];
+
+  // ---- Esquemas de color ----
+  // Paleta apta para daltonismo (se evita el par rojo/verde) y alineada con el
+  // acento indigo de Centinela: indigo = estado bueno/"despues", naranja = costo/"antes".
+  private readonly CENT_INDIGO = '#4F46E5';
+  private readonly CENT_ORANGE = '#EA580C';
+  private readonly CENT_CYAN = '#0891B2';
+  private readonly CENT_VIOLET = '#7C3AED';
+
+  schemeMetric: Color = {
+    name: 'metric',
+    selectable: true,
+    group: ScaleType.Ordinal,
+    domain: [this.CENT_INDIGO, this.CENT_ORANGE, this.CENT_CYAN, this.CENT_VIOLET],
+  };
+  schemeUtil: Color = {
+    name: 'util',
+    selectable: true,
+    group: ScaleType.Ordinal,
+    domain: [this.CENT_ORANGE],
+  };
+  schemeAreas: Color = {
+    name: 'areas',
+    selectable: true,
+    group: ScaleType.Ordinal,
+    domain: [this.CENT_INDIGO],
+  };
+  schemeBeforeAfter: Color = {
+    name: 'ba',
+    selectable: true,
+    group: ScaleType.Ordinal,
+    domain: [this.CENT_ORANGE, this.CENT_INDIGO],
+  };
+  schemeQuery: Color = {
+    name: 'q',
+    selectable: true,
+    group: ScaleType.Ordinal,
+    domain: [this.CENT_ORANGE, this.CENT_INDIGO],
+  };
+
+  constructor(private fairnessService: FairnessService) {}
+
+  ngOnInit(): void {
+    this.fairnessService.getSummary().subscribe({
+      next: (d) => {
+        this.data = d;
+        this.alphaIdx = this.indexOfParam(d.model_mitigation.alpha_sweep.map((p) => p.alpha), d.model_mitigation.alpha_optimo);
+        this.lambdaIdx = this.indexOfParam(d.search_mitigation.lambda_sweep.map((p) => p.lambda), d.search_mitigation.lambda_optimo);
+        this.buildCharts(d);
+        this.loading = false;
+      },
+      error: (e) => {
+        this.error =
+          e?.status === 0
+            ? 'No se pudo conectar con el servidor.'
+            : 'Error cargando los datos de fairness. Verifique que el backend tenga fairness_dashboard.json.';
+        this.loading = false;
+      },
+    });
+  }
+
+  // Punto del barrido seleccionado por el slider
+  get alphaPoint(): AlphaPoint | undefined {
+    return this.data?.model_mitigation.alpha_sweep[this.alphaIdx];
+  }
+  get lambdaPoint(): LambdaPoint | undefined {
+    return this.data?.search_mitigation.lambda_sweep[this.lambdaIdx];
+  }
+
+  // Cumplimiento de umbrales en el punto seleccionado
+  get alphaUtilOk(): boolean {
+    return (this.alphaPoint?.caida_util ?? 100) <= 5;
+  }
+  get lambdaUtilOk(): boolean {
+    return (this.lambdaPoint?.caida_ndcg ?? 100) <= 5;
+  }
+
+  private indexOfParam(values: number[], target: number): number {
+    let best = 0;
+    let bestDiff = Infinity;
+    values.forEach((v, i) => {
+      const diff = Math.abs(v - target);
+      if (diff < bestDiff) {
+        bestDiff = diff;
+        best = i;
+      }
+    });
+    return best;
+  }
+
+  private r(n: number, d = 2): number {
+    const f = Math.pow(10, d);
+    return Math.round(n * f) / f;
+  }
+
+  private buildCharts(d: FairnessSummary): void {
+    // SHAP: importancia de features
+    this.shapData = d.shap.map((s) => ({ name: s.feature, value: s.pct }));
+
+    // Sensibilidad alpha: DI y SPD
+    const sweep = d.model_mitigation.alpha_sweep;
+    const ax = (p: AlphaPoint) => this.r(p.alpha, 1).toString();
+    this.alphaDiSpd = [
+      { name: 'DI', series: sweep.map((p) => ({ name: ax(p), value: this.r(p.DI, 3) })) },
+      { name: 'SPD', series: sweep.map((p) => ({ name: ax(p), value: this.r(p.SPD, 3) })) },
+    ];
+    this.alphaUtil = [
+      {
+        name: 'Caida utilidad (%)',
+        series: sweep.map((p) => ({ name: ax(p), value: this.r(p.caida_util, 2) })),
+      },
+    ];
+
+    // Sensibilidad lambda: diversidad y caida de NDCG
+    const lsweep = d.search_mitigation.lambda_sweep;
+    const lx = (p: LambdaPoint) => this.r(p.lambda, 1).toString();
+    this.lambdaAreas = [
+      {
+        name: 'Areas unicas (top-50)',
+        series: lsweep.map((p) => ({ name: lx(p), value: this.r(p.n_areas, 1) })),
+      },
+    ];
+    this.lambdaNdcg = [
+      {
+        name: 'Caida NDCG (%)',
+        series: lsweep.map((p) => ({ name: lx(p), value: this.r(p.caida_ndcg, 2) })),
+      },
+    ];
+
+    // Antes/despues (escalas distintas -> dos graficos separados)
+    const mb = d.model_mitigation.baseline;
+    const mt = d.model_mitigation.threshold_adj;
+    this.antesDespuesModelo = [
+      { name: 'Antes', value: this.r(mb['DI'], 3) },
+      { name: 'Después', value: this.r(mt['DI'], 3) },
+    ];
+    this.antesDespuesBuscador = [
+      { name: 'Antes', value: this.r(lsweep[0].n_areas, 1) },
+      { name: 'Después', value: this.r(lsweep[this.lambdaIdx].n_areas, 1) },
+    ];
+
+    // xQUAD por consulta: areas base vs xQUAD
+    this.queryData = d.search_mitigation.comparison.map((c) => ({
+      name: c['query'] as string,
+      series: [
+        { name: 'BM25 (base)', value: c['areas_base'] as number },
+        { name: 'xQUAD', value: c['areas_xquad'] as number },
+      ],
+    }));
+  }
+
+  /** Clase de color segun el estado/veredicto (verde/ambar/rojo). */
+  estadoClass(estado: string): string {
+    const s = (estado || '').toLowerCase();
+    if (s.includes('cumple') && !s.includes('no')) return 'text-green-600 font-semibold';
+    if (s.includes('aceptable') || s.includes('diversa')) return 'text-green-600 font-semibold';
+    if (
+      s.includes('no cumple') ||
+      s.includes('no mitiga') ||
+      s.includes('sesgo') ||
+      s.includes('extrema') ||
+      s.includes('alta') ||
+      s.includes('matthew')
+    ) {
+      return 'text-red-600 font-semibold';
+    }
+    if (s.includes('degrada') || s.includes('limite') || s.includes('moderada')) {
+      return 'text-yellow-600 font-semibold';
+    }
+    return 'text-gray-700';
+  }
+}


### PR DESCRIPTION
## QuÃ© agrega
MÃ³dulo de solo lectura en `/admin/dashboard/fairness` que visualiza las mÃ©tricas de equidad del buscador (SHAP, comparativa antes/despuÃ©s, curvas de sensibilidad de Î± y Î» con sliders, y xQUAD por consulta) usando ngx-charts. Consume 4 endpoints nuevos expuestos en `search_engine_backend` (PR aparte).

## Archivos
- **Nuevos:** entidad `fairness.interface.ts`, servicio `fairness.service.ts`, componente `fairness-dashboard/`.
- **Modificados (aditivo):** `admin.module.ts` (declara el componente + `NgxChartsModule`), `admin-rounting.module.ts` (ruta hija `fairness`), `sidebar.component.html` (link "Equidad").

## Notas
- Totalmente **aditivo y de solo lectura**: no toca el modelo predictivo, el buscador ni componentes existentes.
- Los datos provienen de un JSON precalculado (resultados de los notebooks S5â€“S10 de anÃ¡lisis de sesgos).
- La rama ya incluye el merge de `dev-Marlow` al dÃ­a (sin conflictos).
