### PR TITLE
Configure predictive backend proxy for GRS

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -101,6 +101,11 @@ http {
             proxy_pass $search_microservice_backend;
         }
 
+        location /api-predictiva/ { rewrite ^/api-predictiva/(.*)$ /api/v1/$1 break;
+            proxy_pass http://predictive-backend:8003;
+
+        }
+
         location /api-se/ {
             proxy_pass $search_engine_backend;
         }
@@ -147,5 +152,7 @@ http {
         location / {
             try_files $uri $uri/ /index.html;
         }
+
+        
     }
 }

--- a/nginx_produccion.conf
+++ b/nginx_produccion.conf
@@ -47,7 +47,7 @@ http {
         set $social_consensus_backend http://social-consensus-web:8000;
         set $search_engine_backend http://search-engine-backend:8001;
         set $search_microservice_backend http://search-microservice-backend:8002;
-
+        set $predictive_backend http://predictive-backend:8003;
         root /usr/share/nginx/html;
         index index.html;
         autoindex off;
@@ -123,6 +123,11 @@ http {
 
         location /api/v1/ {
             proxy_pass $social_consensus_backend;
+        }
+
+        location /api-predictiva/ {
+            rewrite ^/api-predictiva/(.*)$ /api/v1/$1 break;
+            proxy_pass $predictive_backend;
         }
 
         location /api-se/v2/ {


### PR DESCRIPTION
Se agrega la configuración de nginx necesaria para exponer el backend predictivo mediante /api-predictiva/.

Cambios:
- Configuración del proxy en nginx.conf para el entorno local.
- Configuración equivalente en nginx_produccion.conf.
- Proxy hacia predictive-backend:8003.
- Reescritura de /api-predictiva/* hacia /api/v1/*.

Validaciones realizadas:
- nginx -t exitoso.
- /api-predictiva/recommendations/health responde con status ok.
- Métricas del GRS cargadas correctamente.
- Listado de grupos y recomendaciones validado en localhost.